### PR TITLE
fix(application): fix file loop and use of GTK object after lifecycle

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -179,6 +179,13 @@ static void save_state_to_file_or_folder(struct swappy_state *state,
   g_object_unref(pixbuf);
 }
 
+void on_destroy(GtkApplication *application, gpointer data) {
+  struct swappy_state *state = (struct swappy_state *)data;
+  if (state->output_file != NULL) {
+    save_state_to_file_or_folder(state, state->output_file);
+  }
+}
+
 void brush_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
   switch_mode_to_brush(state);
 }
@@ -200,9 +207,6 @@ void arrow_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
 }
 
 void application_finish(struct swappy_state *state) {
-  if (state->output_file != NULL) {
-    save_state_to_file_or_folder(state, state->output_file);
-  }
   paint_free_all(state);
   buffer_free_all(state);
   cairo_surface_destroy(state->cairo_surface);
@@ -518,6 +522,8 @@ static bool load_layout(struct swappy_state *state) {
 
   GtkWindow *window =
       GTK_WINDOW(gtk_builder_get_object(builder, "paint-window"));
+
+  g_signal_connect(window, "destroy", G_CALLBACK(on_destroy), state);
 
   state->ui->undo = GTK_BUTTON(gtk_builder_get_object(builder, "undo-button"));
   state->ui->redo = GTK_BUTTON(gtk_builder_get_object(builder, "redo-button"));

--- a/src/pixbuf.c
+++ b/src/pixbuf.c
@@ -13,18 +13,8 @@ GdkPixbuf *pixbuf_get_from_state(struct swappy_state *state) {
   return pixbuf;
 }
 
-void pixbuf_save_state_to_folder(GdkPixbuf *pixbuf, char *folder) {
+static void write_file(GdkPixbuf *pixbuf, char *path) {
   GError *error = NULL;
-
-  time_t current_time;
-  char *c_time_string;
-
-  time(&current_time);
-
-  c_time_string = ctime(&current_time);
-  c_time_string[strlen(c_time_string) - 1] = '\0';
-  char path[MAX_PATH];
-  snprintf(path, MAX_PATH, "%s/%s %s.png", folder, "Swappshot", c_time_string);
   gdk_pixbuf_savev(pixbuf, path, "png", NULL, NULL, &error);
 
   if (error != NULL) {
@@ -38,6 +28,19 @@ void pixbuf_save_state_to_folder(GdkPixbuf *pixbuf, char *folder) {
   snprintf(message, len, "%s%s", msg, path);
   notification_send("Swappy", message);
   g_free(message);
+}
+
+void pixbuf_save_state_to_folder(GdkPixbuf *pixbuf, char *folder) {
+  time_t current_time;
+  char *c_time_string;
+
+  time(&current_time);
+
+  c_time_string = ctime(&current_time);
+  c_time_string[strlen(c_time_string) - 1] = '\0';
+  char path[MAX_PATH];
+  snprintf(path, MAX_PATH, "%s/%s %s.png", folder, "Swappshot", c_time_string);
+  write_file(pixbuf, path);
 }
 
 void pixbuf_save_to_stdout(GdkPixbuf *pixbuf) {
@@ -61,6 +64,6 @@ void pixbuf_save_to_file(GdkPixbuf *pixbuf, char *file) {
   if (g_strcmp0(file, "-") == 0) {
     pixbuf_save_to_stdout(pixbuf);
   } else {
-    pixbuf_save_to_file(pixbuf, file);
+    write_file(pixbuf, file);
   }
 }


### PR DESCRIPTION
Swappy tried to access Gtk data after the end of the mainloop and the
file save routine had infinite recursion