### PR TITLE
fix(pixbuf): properly grab pixbuf size from cairo surface

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "notification.h"
+#include "pixbuf.h"
 #include "util.h"
 
 #define gtk_clipboard_t GtkClipboard
@@ -73,10 +74,7 @@ static void send_pixbuf_to_gdk_clipboard(gdk_pixbuf_t *pixbuf) {
 }
 
 bool clipboard_copy_drawing_area_to_selection(struct swappy_state *state) {
-  int width = gtk_widget_get_allocated_width(state->ui->area);
-  int height = gtk_widget_get_allocated_height(state->ui->area);
-  gdk_pixbuf_t *pixbuf =
-      gdk_pixbuf_get_from_surface(state->cairo_surface, 0, 0, width, height);
+  gdk_pixbuf_t *pixbuf = pixbuf_get_from_state(state);
 
   // Try `wl-copy` first and fall back to gtk function. See README.md.
   if (!send_pixbuf_to_wl_copy(pixbuf)) {

--- a/src/pixbuf.c
+++ b/src/pixbuf.c
@@ -1,12 +1,13 @@
 #include "pixbuf.h"
 
+#include <cairo/cairo.h>
 #include <gio/gunixoutputstream.h>
 
 #include "notification.h"
 
 GdkPixbuf *pixbuf_get_from_state(struct swappy_state *state) {
-  guint width = gtk_widget_get_allocated_width(state->ui->area);
-  guint height = gtk_widget_get_allocated_height(state->ui->area);
+  guint width = cairo_image_surface_get_width(state->cairo_surface);
+  guint height = cairo_image_surface_get_height(state->cairo_surface);
   GdkPixbuf *pixbuf =
       gdk_pixbuf_get_from_surface(state->cairo_surface, 0, 0, width, height);
 


### PR DESCRIPTION
This fixes the scaling issue when user would copy or save the file.

Commit `445980b` only solved the rendering part not the pixbuf part.

Closes #6