### PR TITLE
chore(release): add bump meson script

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,8 @@
+{
+  "bumpFiles": [
+    {
+      "filename": "meson.build",
+      "updater": "script/bump-meson-build.js"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,16 @@ ninja -C build
 
 ## Contributing
 
-Pull requests are welcome.
+Pull requests are welcome. This project uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate changelog generation.
+
+## Generating a new release
+
+This is only for maintainers, to create a new release. We rely on [standard-version](https://github.com/conventional-changelog/standard-version) which is part of the JavaScript ecosystem but works well with any project.
+
+```
+npx standard-version --sign
+git push --follow-tags
+```
 
 ## License
 

--- a/script/bump-meson-build.js
+++ b/script/bump-meson-build.js
@@ -1,0 +1,11 @@
+const projectVersionRegExp = /version: '(?<version>\d+\.\d+\.\d+)',/;
+
+module.exports.readVersion = function (contents) {
+  const matches = contents.match(projectVersionRegExp);
+
+  return matches ? matches[1] : "unknown";
+};
+
+module.exports.writeVersion = function (_contents, version) {
+  return _contents.replace(projectVersionRegExp, `version: '${version}',`);
+};


### PR DESCRIPTION
Mixing C code with Javascript files, what's not to love.

Simply run the following line to generate a new standard version:

```
npx standard-version --sign
```