### PR TITLE
feat(i18n): add translatable desktop file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ if libnotify.found()
 endif
 
 subdir('res')
+subdir('src/po')
 
 executable(
 	'swappy',

--- a/res/icons/hicolor/scalable/apps/swappy.svg
+++ b/res/icons/hicolor/scalable/apps/swappy.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="SVGRoot"
+   version="1.1"
+   viewBox="0 0 1024.0 1024.0"
+   height="1024.0px"
+   width="1024.0px"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="swappy.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs10">
+    <rect
+       x="20"
+       y="40"
+       width="40"
+       height="60"
+       id="rect884" />
+    <rect
+       x="60"
+       y="60"
+       width="880"
+       height="900"
+       id="rect28" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="304.02737"
+     inkscape:cy="526.91724"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     inkscape:window-width="3436"
+     inkscape:window-height="1385"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:snap-grids="false"
+     inkscape:snap-to-guides="false">
+    <inkscape:grid
+       id="grid19"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       y="1.6967406"
+       x="0.039459083"
+       height="1021.6036"
+       width="1022.736"
+       id="rect845"
+       style="fill:#008080;stroke-width:10" />
+    <g
+       style="font-size:40px;line-height:1.25;font-family:'JetBrains Mono';-inkscape-font-specification:'JetBrains Mono';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect884);fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke-width:1.50525;stroke-miterlimit:4;stroke-dasharray:none"
+       id="text882"
+       transform="matrix(35.991264,0,0,30.102317,-925.6893,-1358.2835)"
+       aria-label="S">
+      <path
+         sodipodi:nodetypes="sscccscscccsssccccccsscccscs"
+         id="path866"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke-width:1.50525;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 40.000031,76.690323 c -1.36,0 -2.6,-0.186667 -3.72,-0.56 -1.12,-0.373333 -2.08,-0.893333 -2.88,-1.56 -0.8,-0.693333 -1.426667,-1.52 -1.88,-2.48 2.53775,0.03675 2.688198,0.02299 4.56,0.16 1.013333,0.826667 2.346667,1.24 4,1.24 1.706667,0 3.04,-0.386667 4,-1.16 0.96,-0.8 1.44,-1.88 1.44,-3.24 0,-1.173333 -0.346667,-2.2 -1.04,-3.08 -0.693333,-0.906667 -1.64,-1.573333 -2.84,-2 l -3.4,-1.2 c -4.373333,-1.573333 -6.56,-4.28 -6.56,-8.12 0,-2.346667 0.76,-4.2 2.28,-5.56 1.52,-1.36 3.6,-2.04 6.24,-2.04 1.28,0 2.44,0.186667 3.48,0.56 1.066667,0.346667 1.973333,0.853333 2.72,1.52 0.773333,0.666667 1.321216,1.466663 1.721216,2.426663 -1.199656,-0.0108 -2.466771,0.07564 -4.441216,-0.106663 -0.980116,-0.483996 -1.985327,-1.183902 -3.52,-1.2 -1.493333,0 -2.68,0.373333 -3.56,1.12 -0.88,0.72 -1.32,1.706667 -1.32,2.96 0,1.173333 0.32,2.146667 0.96,2.92 0.64,0.773333 1.68,1.426667 3.12,1.96 l 3.56,1.28 c 2.026667,0.72 3.573333,1.813333 4.64,3.28 1.093333,1.44 1.64,3.16 1.64,5.16 0,2.4 -0.826667,4.293333 -2.48,5.68 -1.626667,1.36 -3.866667,2.04 -6.72,2.04 z" />
+    </g>
+    <path
+       sodipodi:type="star"
+       style="fill:#f78a00;fill-opacity:1;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path888"
+       sodipodi:sides="3"
+       sodipodi:cx="257.94193"
+       sodipodi:cy="660"
+       sodipodi:r1="114.12712"
+       sodipodi:r2="58.309521"
+       sodipodi:arg1="0.50284321"
+       sodipodi:arg2="1.5500408"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 357.94192,715 -197.63139,4.10254 95.26279,-173.20508 z"
+       inkscape:transform-center-x="-51.091895"
+       inkscape:transform-center-y="-25.05203"
+       transform="matrix(2.3839593,-0.73466722,0.94986547,2.239335,-973.42815,-573.62046)" />
+    <path
+       d="M 598.41022,191.69452 H 898.85495 V 438.75989 H 598.41022 Z"
+       style="fill:#cf00cf;fill-opacity:1;stroke:none;stroke-width:21.0202;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect890" />
+  </g>
+</svg>

--- a/res/meson.build
+++ b/res/meson.build
@@ -2,6 +2,11 @@
 # resources will be compiled.
 gnome = import('gnome')
 
+# Icons
+install_subdir('icons',
+  install_dir: join_paths(get_option('datadir')),
+)
+
 swappy_resources = gnome.compile_resources('swappy',
   'swappy.gresource.xml'
 )

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -92,7 +92,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">B</property>
+                        <property name="label" translatable="no">B</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -104,7 +104,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">T</property>
+                        <property name="label" translatable="no">T</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -116,7 +116,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">R</property>
+                        <property name="label" translatable="no">R</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -128,7 +128,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">O</property>
+                        <property name="label" translatable="no">O</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -140,7 +140,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">A</property>
+                        <property name="label" translatable="no">A</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -152,7 +152,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">D</property>
+                        <property name="label" translatable="no">D</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -176,7 +176,7 @@
                     <property name="homogeneous">True</property>
                     <child>
                       <object class="GtkRadioButton" id="brush">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>
@@ -192,7 +192,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="text">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>
@@ -208,7 +208,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="rectangle">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>
@@ -224,7 +224,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="ellipse">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>
@@ -240,7 +240,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="arrow">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>
@@ -256,7 +256,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="blur">
-                        <property name="label" translatable="yes"></property>
+                        <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="receives_default">False</property>

--- a/src/po/LINGUAS
+++ b/src/po/LINGUAS
@@ -1,0 +1,2 @@
+# Set of available languages.
+en

--- a/src/po/POTFILES
+++ b/src/po/POTFILES
@@ -1,0 +1,1 @@
+res/swappy.glade

--- a/src/po/en.po
+++ b/src/po/en.po
@@ -1,0 +1,50 @@
+# English translations for swappy package.
+# Copyright (C) 2020 THE swappy'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the swappy package.
+# Automatically generated, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: swappy\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-21 21:57-0400\n"
+"PO-Revision-Date: 2020-06-21 21:57-0400\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: res/swappy.glade:455
+msgid "Line Width"
+msgstr "Line Width"
+
+#: res/swappy.glade:525
+msgid "Text Size"
+msgstr "Text Size"
+
+#: res/swappy.glade:641
+msgid "Toggle Paint Panel"
+msgstr "Toggle Paint Panel"
+
+#: res/swappy.glade:667
+msgid "Undo Last Paint"
+msgstr "Undo Last Paint"
+
+#: res/swappy.glade:686
+msgid "Redo Previous Paint"
+msgstr "Redo Previous Paint"
+
+#: res/swappy.glade:705
+msgid "Clear Paints"
+msgstr "Clear Paints"
+
+#: res/swappy.glade:733
+msgid "Copy Surface"
+msgstr "Copy Surface"
+
+#: res/swappy.glade:749
+msgid "Save Surface"
+msgstr "Save Surface"

--- a/src/po/meson.build
+++ b/src/po/meson.build
@@ -1,0 +1,8 @@
+i18n = import('i18n')
+
+# define GETTEXT_PACKAGE
+add_project_arguments('-DGETTEXT_PACKAGE="intltest"', language:'c')
+
+i18n.gettext(meson.project_name(),
+    args: '--directory=' + meson.source_root()
+)

--- a/src/po/meson.build
+++ b/src/po/meson.build
@@ -6,3 +6,13 @@ add_project_arguments('-DGETTEXT_PACKAGE="intltest"', language:'c')
 i18n.gettext(meson.project_name(),
     args: '--directory=' + meson.source_root()
 )
+
+# Translate and install our .desktop file
+i18n.merge_file(
+    input: meson.project_name() + '.desktop.in',
+    output: meson.project_name() + '.desktop',
+    po_dir: meson.current_source_dir(),
+    type: 'desktop',
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'applications')
+)

--- a/src/po/swappy.desktop.in
+++ b/src/po/swappy.desktop.in
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Swappy
+GenericName=Annotation Tool
+Comment=A Wayland native snapshot editing tool
+TryExec=swappy
+Exec=swappy -f %F
+Terminal=true
+Type=Application
+Keywords=wayland;snapshot;annotation;editing;
+Icon=swappy
+Categories=Utility;Graphics;Annotation;
+StartupNotify=true
+MimeType=image/png;

--- a/src/po/swappy.pot
+++ b/src/po/swappy.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the swappy package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: swappy\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-21 21:57-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: res/swappy.glade:455
+msgid "Line Width"
+msgstr ""
+
+#: res/swappy.glade:525
+msgid "Text Size"
+msgstr ""
+
+#: res/swappy.glade:641
+msgid "Toggle Paint Panel"
+msgstr ""
+
+#: res/swappy.glade:667
+msgid "Undo Last Paint"
+msgstr ""
+
+#: res/swappy.glade:686
+msgid "Redo Previous Paint"
+msgstr ""
+
+#: res/swappy.glade:705
+msgid "Clear Paints"
+msgstr ""
+
+#: res/swappy.glade:733
+msgid "Copy Surface"
+msgstr ""
+
+#: res/swappy.glade:749
+msgid "Save Surface"
+msgstr ""


### PR DESCRIPTION
- use of `gettext` with `meson` i18n module.
- Includes the first swappy logo, yay !
- Includes a desktop file that registers mime type for png files