### PR TITLE
docs(readme): Add openSUSE install

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ text_font=sans-serif
 - [Arch Linux](https://aur.archlinux.org/packages/swappy)
 - [Arch Linux (git)](https://aur.archlinux.org/packages/swappy-git)
 - [Fedora 31/32](https://copr.fedorainfracloud.org/coprs/wef/swappy)
+- [openSUSE](https://build.opensuse.org/package/show/X11:Wayland/swappy)
 
 ## Building from source
 


### PR DESCRIPTION
swappy will be in the official repos for openSUSE Tumbleweed.