### PR TITLE
fix: notification show the image icon

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -8,7 +8,7 @@ void notification_send(char *title, char *message) {
 #ifdef HAVE_LIBNOTIFY
   notify_init("Hello world!");
   NotifyNotification *notification =
-      notify_notification_new(title, message, "dialog-information");
+      notify_notification_new(title, message, "image");
   notify_notification_show(notification, NULL);
   g_object_unref(G_OBJECT(notification));
   notify_uninit();


### PR DESCRIPTION
The notification will show an image icon instead of the dialog notification icon.
![Swappshot Tue Dec 15 20:59:50 2020](https://user-images.githubusercontent.com/49378990/102295631-c4989b80-3f19-11eb-9264-b8861ac368ca.png)
