### PR TITLE
fix(i18n): properly set translation domain during layout init

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -684,6 +684,10 @@ static bool load_layout(struct swappy_state *state) {
 
   /* Construct a GtkBuilder instance and load our UI description */
   GtkBuilder *builder = gtk_builder_new();
+
+  // Set translation domain for the application based on `src/po/meson.build`
+  gtk_builder_set_translation_domain(builder, GETTEXT_PACKAGE);
+
   if (gtk_builder_add_from_resource(builder, "/me/jtheoof/swappy/swappy.glade",
                                     &error) == 0) {
     g_printerr("Error loading file: %s", error->message);


### PR DESCRIPTION
Most of the `i18n` boilerplate was there, but the app still needed to
know what domain to look for. This must happen after initialization of
the `GtkBuilder` and before loading the glade file.

The domain is simply the `mo` file packaged with the app and usually
located under:


```
/usr/share/locale/$LANG/LC_MESSAGES/$APP.mo
```

Once again thanks to @maximbaz for pointing it out.

Closes #92