### PR TITLE
Extend desktop file to support screenshot actions

### DIFF
--- a/src/po/swappy.desktop.in
+++ b/src/po/swappy.desktop.in
@@ -17,3 +17,20 @@ Icon=swappy
 Categories=Utility;Graphics;Annotation;
 StartupNotify=true
 MimeType=image/png;image/jpeg;
+Actions=current-window;current-output;select-window;select-area;
+
+[Desktop Action current-window]
+Name=Current Window
+Exec=grimshot save active - | swappy -f -
+
+[Desktop Action current-output]
+Name=Current Output
+Exec=grimshot save output - | swappy -f -
+
+[Desktop Action select-window]
+Name=Select Window
+Exec=grimshot save window - | swappy -f -
+
+[Desktop Action select-area]
+Name=Select Area
+Exec=grimshot save area - | swappy -f -


### PR DESCRIPTION
It's super convenient to be able to take a screenshot and pass it to
Swappy in one step.

Actions in the .desktop file feel like a natural place to offer
these options.

Using rofi as a launcher, ".desktop" file actions are findable
if the -drun-show-actions is passed.

With these actions, you can snapshot any of the following and have
the result opened in swappy:

 - current window
 - current output
 - select a window
 - select an area

The downside is that these depend on `grimshot`, which is part of
the `sway` project in the `contrib/` directory there.

Some of the grimshot logic in turn depends on `swaymsg`.

Maybe these desktop actions are better hosted in another project
since this one currently doesn't depend on Sway, but I thought
I would share the idea here to start a conversation.

Another option would be to create a `contrib/grimshot-swappy.desktop`
file. Sway users could opt to install it.

Thanks!
