### PR TITLE
fix(pixbuf): handle invalid input file

### DIFF
--- a/include/pixbuf.h
+++ b/include/pixbuf.h
@@ -10,3 +10,4 @@ void pixbuf_save_to_file(GdkPixbuf *pixbuf, char *file);
 void pixbuf_save_to_stdout(GdkPixbuf *pixbuf);
 void pixbuf_scale_surface_from_widget(struct swappy_state *state,
                                       GtkWidget *widget);
+void pixbuf_free(struct swappy_state *state);

--- a/src/application.c
+++ b/src/application.c
@@ -256,6 +256,7 @@ void blur_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
 
 void application_finish(struct swappy_state *state) {
   paint_free_all(state);
+  pixbuf_free(state);
   cairo_surface_destroy(state->rendering_surface);
   cairo_surface_destroy(state->original_image_surface);
   if (state->temp_file_str) {
@@ -269,7 +270,7 @@ void application_finish(struct swappy_state *state) {
   g_free(state->geometry);
   g_free(state->window);
   g_free(state->ui);
-  g_object_unref(state->original_image);
+
   g_object_unref(state->app);
 
   config_free(state);

--- a/src/pixbuf.c
+++ b/src/pixbuf.c
@@ -70,7 +70,8 @@ GdkPixbuf *pixbuf_init_from_file(struct swappy_state *state) {
   GdkPixbuf *image = gdk_pixbuf_new_from_file(file, &error);
 
   if (error != NULL) {
-    g_error("unable to load file: %s - reason: %s", file, error->message);
+    g_printerr("unable to load file: %s - reason: %s\n", file, error->message);
+    g_error_free(error);
     return NULL;
   }
 
@@ -135,4 +136,10 @@ finish:
   state->rendering_surface = rendering_surface;
 
   g_free(alloc);
+}
+
+void pixbuf_free(struct swappy_state *state) {
+  if (G_IS_OBJECT(state->original_image)) {
+    g_object_unref(state->original_image);
+  }
 }


### PR DESCRIPTION
If the input file is invalid (example: `grim` did not work due to
invalid geometry), handle the error gracefully.

Previously we had a coredump due to `g_error`.