### PR TITLE
Remove Annotation keyword from desktop categories

### DIFF
--- a/src/po/swappy.desktop.in
+++ b/src/po/swappy.desktop.in
@@ -14,6 +14,6 @@ Terminal=true
 Type=Application
 Keywords=wayland;snapshot;annotation;editing;
 Icon=swappy
-Categories=Utility;Graphics;Annotation;
+Categories=Utility;Graphics;
 StartupNotify=true
 MimeType=image/png;image/jpeg;


### PR DESCRIPTION
## Description
I'm working on packaging this for Gentoo, and the Annotation category is not a valid category in the xdg specification, causing problems for our build process.

See https://specifications.freedesktop.org/menu-spec/latest/apa.html
See https://github.com/gentoo/gentoo/pull/18652#pullrequestreview-601579680