### PR TITLE
Create `save_dir` if it does not exist, and allow configuration of starting painting mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ show_panel=false
 line_size=5
 text_size=20
 text_font=sans-serif
+paint_mode=brush
 ```
 
-- `save_dir` is where swappshots will be saved, can contain env variables and must exist in your filesystem
+- `save_dir` is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
 - `save_filename_format`: is the filename template, if it contains a date format, this will be parsed into a timestamp. Format is detailed in [strftime(3)](https://man.archlinux.org/man/strftime.3). If this date format is missing, filename will have no timestamp
 - `show_panel` is used to toggle the paint panel on or off upon startup
 - `line_size` is the default line size (must be between 1 and 50)
 - `text_size` is the default text size (must be between 10 and 50)
 - `text_font` is the font used to render text, its format is pango friendly
+- `paint_mode` is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
 
 ## Keyboard Shortcuts
 

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,7 @@
 #define CONFIG_TEXT_SIZE_DEFAULT 20
 #define CONFIG_SHOW_PANEL_DEFAULT false
 #define CONFIG_SAVE_FILENAME_FORMAT_DEFAULT "swappy-%Y%m%d_%H%M%S.png"
+#define CONFIG_PAINT_MODE_DEFAULT SWAPPY_PAINT_MODE_BRUSH
 
 void config_load(struct swappy_state *state);
 void config_free(struct swappy_state *state);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -143,6 +143,7 @@ struct swappy_config {
   char *config_file;
   char *save_dir;
   char *save_filename_format;
+  gint8 paint_mode;
   gboolean show_panel;
   guint32 line_size;
   guint32 text_size;

--- a/src/application.c
+++ b/src/application.c
@@ -762,6 +762,32 @@ static bool load_layout(struct swappy_state *state) {
   return true;
 }
 
+static void set_paint_mode(struct swappy_state *state) {
+  switch (state->mode) {
+    case SWAPPY_PAINT_MODE_BRUSH:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->brush), true);
+      break;
+    case SWAPPY_PAINT_MODE_TEXT:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->text), true);
+      break;
+    case SWAPPY_PAINT_MODE_RECTANGLE:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->rectangle),
+                                   true);
+      break;
+    case SWAPPY_PAINT_MODE_ELLIPSE:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->ellipse), true);
+      break;
+    case SWAPPY_PAINT_MODE_ARROW:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->arrow), true);
+      break;
+    case SWAPPY_PAINT_MODE_BLUR:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->blur), true);
+      break;
+    default:
+      break;
+  }
+}
+
 static bool init_gtk_window(struct swappy_state *state) {
   if (!state->original_image) {
     g_critical("original image not loaded");
@@ -775,6 +801,8 @@ static bool init_gtk_window(struct swappy_state *state) {
   if (!load_css(state)) {
     return false;
   }
+
+  set_paint_mode(state);
 
   update_ui_stroke_size_widget(state);
   update_ui_text_size_widget(state);
@@ -799,6 +827,7 @@ static void init_settings(struct swappy_state *state) {
   state->settings.a = 1;
   state->settings.w = state->config->line_size;
   state->settings.t = state->config->text_size;
+  state->mode = state->config->paint_mode;
 }
 
 static gint command_line_handler(GtkApplication *app,

--- a/src/config.c
+++ b/src/config.c
@@ -97,7 +97,11 @@ static void load_config_from_file(struct swappy_config *config,
       save_dir_expanded = g_strdup(p.we_wordv[0]);
       wordfree(&p);
       if (!save_dir_expanded || !folder_exists(save_dir_expanded)) {
-        g_warning("save_dir: %s is not a valid directory", save_dir_expanded);
+        g_info("save_dir: attempting to create non-existent directory '%s'",
+               save_dir_expanded);
+        if (g_mkdir_with_parents(save_dir_expanded, 0755)) {
+          g_warning("save_dir: failed to create '%s'", save_dir_expanded);
+        }
       }
 
       g_free(save_dir);

--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,7 @@ static void print_config(struct swappy_config *config) {
   g_info("line_size: %d", config->line_size);
   g_info("text_font: %s", config->text_font);
   g_info("text_size: %d", config->text_size);
+  g_info("paint_mode: %d", config->paint_mode);
 }
 
 static char *get_default_save_dir() {
@@ -75,6 +76,7 @@ static void load_config_from_file(struct swappy_config *config,
   gchar *save_dir_expanded = NULL;
   guint64 line_size, text_size;
   gchar *text_font = NULL;
+  gchar *paint_mode = NULL;
   GError *error = NULL;
 
   if (file == NULL) {
@@ -180,6 +182,32 @@ static void load_config_from_file(struct swappy_config *config,
     error = NULL;
   }
 
+  paint_mode = g_key_file_get_string(gkf, group, "paint_mode", &error);
+
+  if (error == NULL) {
+    if (g_ascii_strcasecmp(paint_mode, "brush") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_BRUSH;
+    } else if (g_ascii_strcasecmp(paint_mode, "text") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_TEXT;
+    } else if (g_ascii_strcasecmp(paint_mode, "rectangle") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_RECTANGLE;
+    } else if (g_ascii_strcasecmp(paint_mode, "ellipse") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_ELLIPSE;
+    } else if (g_ascii_strcasecmp(paint_mode, "arrow") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_ARROW;
+    } else if (g_ascii_strcasecmp(paint_mode, "blur") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_BLUR;
+    } else {
+      g_warning(
+          "paint_mode is not a valid value: %s - see man page for details",
+          paint_mode);
+    }
+  } else {
+    g_info("paint_mode is missing in %s (%s)", file, error->message);
+    g_error_free(error);
+    error = NULL;
+  }
+
   g_key_file_free(gkf);
 }
 
@@ -194,6 +222,7 @@ static void load_default_config(struct swappy_config *config) {
   config->text_font = g_strdup(CONFIG_TEXT_FONT_DEFAULT);
   config->text_size = CONFIG_TEXT_SIZE_DEFAULT;
   config->show_panel = CONFIG_SHOW_PANEL_DEFAULT;
+  config->paint_mode = CONFIG_PAINT_MODE_DEFAULT;
 }
 
 void config_load(struct swappy_state *state) {

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -63,14 +63,16 @@ The following lines can be used as swappy's default:
 	line_size=5
 	text_size=20
 	text_font=sans-serif
+	paint_mode=brush
 ```
 
-- *save_dir* is where swappshots will be saved, can contain env variables and must exist in your filesystem
+- *save_dir* is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
 - *save_filename_format* is the filename template, if it contains a date format, this will be parsed into a timestamp. Format is detailed in strftime(3). If this date format is missing, filename will have no timestamp
 - *show_panel* is used to toggle the paint panel on or off upon startup
 - *line_size* is the default line size (must be between 1 and 50)
 - *text_size* is the default text size (must be between 10 and 50)
 - *text_font* is the font used to render text, its format is pango friendly
+- *paint_mode* is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
 
 # KEY BINDINGS
 


### PR DESCRIPTION
I have made 2 changes:

1. The current behavior of swappy is to assume `save_dir` to exist, when trying to save edited image to a non-existing `save_dir`, swappy does not save it at all.  In 0b1c6e9, I add code to attempt to create `save_dir` if it does not already exists.
2. I also added a configuration option `paint_mode` in b6c2c60, to allow a user to configure the start up painting mode of swappy.

Documentation and readme are updated according to the above 2 modifications in 476ae90.