### PR TITLE
feat(config): add quit_on_copy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ line_size=5
 text_size=20
 text_font=sans-serif
 paint_mode=brush
+early_exit=false
 ```
 
 - `save_dir` is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -58,6 +59,7 @@ paint_mode=brush
 - `text_size` is the default text size (must be between 10 and 50)
 - `text_font` is the font used to render text, its format is pango friendly
 - `paint_mode` is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
+- `early_exit` is used to make the application exit after saving the picture or copying it to the clipboard 
 
 ## Keyboard Shortcuts
 

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,7 @@
 #define CONFIG_SHOW_PANEL_DEFAULT false
 #define CONFIG_SAVE_FILENAME_FORMAT_DEFAULT "swappy-%Y%m%d_%H%M%S.png"
 #define CONFIG_PAINT_MODE_DEFAULT SWAPPY_PAINT_MODE_BRUSH
+#define CONFIG_EARLY_EXIT_DEFAULT false
 
 void config_load(struct swappy_state *state);
 void config_free(struct swappy_state *state);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -148,6 +148,7 @@ struct swappy_config {
   guint32 line_size;
   guint32 text_size;
   char *text_font;
+  gboolean early_exit;
 };
 
 struct swappy_state {

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -82,5 +82,9 @@ bool clipboard_copy_drawing_area_to_selection(struct swappy_state *state) {
 
   g_object_unref(pixbuf);
 
+  if (state->config->early_exit) {
+    gtk_main_quit();
+  }
+
   return true;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -20,6 +20,7 @@ static void print_config(struct swappy_config *config) {
   g_info("text_font: %s", config->text_font);
   g_info("text_size: %d", config->text_size);
   g_info("paint_mode: %d", config->paint_mode);
+  g_info("early_exit: %d", config->early_exit);
 }
 
 static char *get_default_save_dir() {
@@ -77,6 +78,7 @@ static void load_config_from_file(struct swappy_config *config,
   guint64 line_size, text_size;
   gchar *text_font = NULL;
   gchar *paint_mode = NULL;
+  gboolean early_exit;
   GError *error = NULL;
 
   if (file == NULL) {
@@ -182,6 +184,16 @@ static void load_config_from_file(struct swappy_config *config,
     error = NULL;
   }
 
+  early_exit = g_key_file_get_boolean(gkf, group, "early_exit", &error);
+
+  if (error == NULL) {
+    config->early_exit = early_exit;
+  } else {
+    g_info("early_exit is missing in %s (%s)", file, error->message);
+    g_error_free(error);
+    error = NULL;
+  }
+
   paint_mode = g_key_file_get_string(gkf, group, "paint_mode", &error);
 
   if (error == NULL) {
@@ -223,6 +235,7 @@ static void load_default_config(struct swappy_config *config) {
   config->text_size = CONFIG_TEXT_SIZE_DEFAULT;
   config->show_panel = CONFIG_SHOW_PANEL_DEFAULT;
   config->paint_mode = CONFIG_PAINT_MODE_DEFAULT;
+  config->early_exit = CONFIG_EARLY_EXIT_DEFAULT;
 }
 
 void config_load(struct swappy_state *state) {

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -64,6 +64,7 @@ The following lines can be used as swappy's default:
 	text_size=20
 	text_font=sans-serif
 	paint_mode=brush
+	early_exit=false
 ```
 
 - *save_dir* is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -73,6 +74,8 @@ The following lines can be used as swappy's default:
 - *text_size* is the default text size (must be between 10 and 50)
 - *text_font* is the font used to render text, its format is pango friendly
 - *paint_mode* is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
+- *early_exit* is used to make the application exit after saving the picture or copying it to the clipboard
+
 
 # KEY BINDINGS
 


### PR DESCRIPTION
if the quit_on_copy config option is set to true, the application now exits after copying the selection to the keyboard