### PR TITLE
Add a custom_color config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ paint_mode=brush
 early_exit=false
 fill_shape=false
 auto_save=false
+custom_color=rgba(193,125,17,1)
 ```
 
 - `save_dir` is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -64,6 +65,9 @@ auto_save=false
 - `early_exit` is used to make the application exit after saving the picture or copying it to the clipboard
 - `fill_shape` is used to toggle shape filling (for the rectangle and ellipsis tools) on or off upon startup
 - `auto_save` is used to toggle auto saving of final buffer to `save_dir` upon exit
+- `early_exit` is used to make the application exit after saving the picture or copying it to the clipboard 
+- `custom_color` is used to set a default value for the custom color
+
 
 ## Keyboard Shortcuts
 

--- a/include/config.h
+++ b/include/config.h
@@ -9,6 +9,7 @@
 #define CONFIG_EARLY_EXIT_DEFAULT false
 #define CONFIG_FILL_SHAPE_DEFAULT false
 #define CONFIG_AUTO_SAVE_DEFAULT false
+#define CONFIG_CUSTOM_COLOR_DEFAULT "rgba(193,125,17,1)"
 
 void config_load(struct swappy_state *state);
 void config_free(struct swappy_state *state);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -153,6 +153,7 @@ struct swappy_config {
   char *text_font;
   gboolean early_exit;
   gboolean auto_save;
+  char *custom_color;
 };
 
 struct swappy_state {

--- a/src/application.c
+++ b/src/application.c
@@ -721,6 +721,8 @@ static bool load_css(struct swappy_state *state) {
 
 static bool load_layout(struct swappy_state *state) {
   GError *error = NULL;
+  // init color
+  GdkRGBA color;
 
   /* Construct a GtkBuilder instance and load our UI description */
   GtkBuilder *builder = gtk_builder_new();
@@ -784,6 +786,9 @@ static bool load_layout(struct swappy_state *state) {
 
   state->ui->fill_shape = GTK_TOGGLE_BUTTON(
       gtk_builder_get_object(builder, "fill-shape-toggle-button"));
+
+  gdk_rgba_parse(&color, state->config->custom_color);
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(state->ui->color), &color);
 
   state->ui->brush = brush;
   state->ui->text = text;

--- a/src/config.c
+++ b/src/config.c
@@ -23,6 +23,7 @@ static void print_config(struct swappy_config *config) {
   g_info("early_exit: %d", config->early_exit);
   g_info("fill_shape: %d", config->fill_shape);
   g_info("auto_save: %d", config->auto_save);
+  g_info("custom_color: %s", config->custom_color);
 }
 
 static char *get_default_save_dir() {
@@ -83,6 +84,7 @@ static void load_config_from_file(struct swappy_config *config,
   gboolean early_exit;
   gboolean fill_shape;
   gboolean auto_save;
+  gchar *custom_color = NULL;
   GError *error = NULL;
 
   if (file == NULL) {
@@ -240,6 +242,14 @@ static void load_config_from_file(struct swappy_config *config,
     config->auto_save = auto_save;
   } else {
     g_info("auto_save is missing in %s (%s)", file, error->message);
+  }
+
+  custom_color = g_key_file_get_string(gkf, group, "custom_color", &error);
+
+  if (error == NULL) {
+    config->custom_color = custom_color;
+  } else {
+    g_info("custom_color is missing in %s (%s)", file, error->message);
     g_error_free(error);
     error = NULL;
   }
@@ -262,6 +272,7 @@ static void load_default_config(struct swappy_config *config) {
   config->early_exit = CONFIG_EARLY_EXIT_DEFAULT;
   config->fill_shape = CONFIG_FILL_SHAPE_DEFAULT;
   config->auto_save = CONFIG_AUTO_SAVE_DEFAULT;
+  config->custom_color = CONFIG_CUSTOM_COLOR_DEFAULT;
 }
 
 void config_load(struct swappy_state *state) {
@@ -288,6 +299,7 @@ void config_free(struct swappy_state *state) {
     g_free(state->config->save_dir);
     g_free(state->config->save_filename_format);
     g_free(state->config->text_font);
+    g_free(state->config->custom_color);
     g_free(state->config);
     state->config = NULL;
   }

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -67,6 +67,7 @@ The following lines can be used as swappy's default:
 	early_exit=false
 	fill_shape=false
 	auto_save=false
+	custom_color=rgba(192,125,17,1)
 ```
 
 - *save_dir* is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -79,6 +80,7 @@ The following lines can be used as swappy's default:
 - *early_exit* is used to make the application exit after saving the picture or copying it to the clipboard
 - *fill_shape* is used to toggle shape filling (for the rectangle and ellipsis tools) on or off upon startup
 - *auto_save* is used to toggle auto saving of final buffer to *save_dir* upon exit
+- *custom_color* is used to set a default value for the custom color
 
 
 # KEY BINDINGS


### PR DESCRIPTION
This PR adds a config option to set the default color for the custom color option.
This way, if you often use the same color, you can set it as a config option.

It uses the gdk function `gdk_rgba_parse` which supports `hex, rgb(),rgba()` aswell as a standard name.

Docs:

> The string can be either one of: - A standard name (Taken from the X11 rgb.txt file). - A hexadecimal value in the form “#rgb”, “#rrggbb”, “#rrrgggbbb” or ”#rrrrggggbbbb” - A RGB color in the form “rgb(r,g,b)” (In this case the color will have full opacity) - A RGBA color in the form “rgba(r,g,b,a)”

As for the changes in `application.c`. I was not sure where I should put the code to initialize this color.
If you can tell me where it should go I will change it.