### PR TITLE
fix(ui): Use *-symbolic variant of toolbar icons

### DIFF
--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -5,57 +5,57 @@
   <object class="GtkImage" id="edit-redo">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">edit-redo</property>
+    <property name="icon_name">edit-redo-symbolic</property>
   </object>
   <object class="GtkImage" id="edit-undo">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">edit-undo</property>
+    <property name="icon_name">edit-undo-symbolic</property>
   </object>
   <object class="GtkImage" id="img-clear-paints">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">edit-delete</property>
+    <property name="icon_name">edit-delete-symbolic</property>
   </object>
   <object class="GtkImage" id="img-copy-surface">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">edit-copy</property>
+    <property name="icon_name">edit-copy-symbolic</property>
   </object>
   <object class="GtkImage" id="img-save-surface">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">document-save</property>
+    <property name="icon_name">document-save-symbolic</property>
   </object>
   <object class="GtkImage" id="img-toggle-panel">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">document-properties</property>
+    <property name="icon_name">document-properties-symbolic</property>
   </object>
   <object class="GtkImage" id="zoom-in">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">zoom-in</property>
+    <property name="icon_name">zoom-in-symbolic</property>
   </object>
   <object class="GtkImage" id="zoom-in1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">zoom-in</property>
+    <property name="icon_name">zoom-in-symbolic</property>
   </object>
   <object class="GtkImage" id="zoom-in2">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">zoom-in</property>
+    <property name="icon_name">zoom-in-symbolic</property>
   </object>
   <object class="GtkImage" id="zoom-out">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">zoom-out</property>
+    <property name="icon_name">zoom-out-symbolic</property>
   </object>
   <object class="GtkImage" id="zoom-out1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">zoom-out</property>
+    <property name="icon_name">zoom-out-symbolic</property>
   </object>
   <object class="GtkApplicationWindow" id="paint-window">
     <property name="visible">True</property>
@@ -787,10 +787,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="zoom-out2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">zoom-out</property>
   </object>
 </interface>


### PR DESCRIPTION
The non-symbolic variant might be indistinguishable from the background.

Fixes #34
Ref: https://wiki.gnome.org/Design/OS/SymbolicIcons

## Before

`GTK_THEME=Materia swappy -f foo.png:`

![image](https://user-images.githubusercontent.com/5774651/202830376-fadc3cb8-23c2-4b2b-ae33-b0aac1630c27.png)

`GTK_THEME=Materia-light swappy -f foo.png:`
![image](https://user-images.githubusercontent.com/5774651/202830153-7a7ddcba-a176-498d-bc90-6410194ecad2.png)

`GTK_THEME=Materia-dark swappy -f foo.png:`
![image](https://user-images.githubusercontent.com/5774651/202830181-6dfde6d5-d2ba-486f-8fc5-3c15ccef2ca4.png)

## After

`GTK_THEME=Materia swappy -f foo.png:`

![image](https://user-images.githubusercontent.com/5774651/202830432-f67f5952-5a60-4c24-88f3-4e3052635505.png)

`GTK_THEME=Materia-light swappy -f foo.png:`

![image](https://user-images.githubusercontent.com/5774651/202830501-68a73901-79e9-41eb-99de-dc86d3933ca5.png)

`GTK_THEME=Materia-dark swappy -f foo.png:`

![image](https://user-images.githubusercontent.com/5774651/202830530-8dd4c974-4005-49af-a701-5c70f6bd9ba0.png)