### PR TITLE
fix(ui): Specify a non-versioned FontAwesome

### DIFF
--- a/res/style/swappy.css
+++ b/res/style/swappy.css
@@ -1,5 +1,5 @@
 .drawing .text-button {
-  font-family: "FontAwesome 5 Free Solid";
+  font-family: "FontAwesome 5 Free Solid", "FontAwesome";
   padding: 4px;
 }
 


### PR DESCRIPTION
The current css specifies "FontAwesome 5 Free Solid", for .drawing and .text-button. This results in the button icons/fonts not rendering correctly on systems that do not have that exact version of FontAwesome. This change allows the icons/fonts to be rendered correctly on these systems.

This should resolve issues like https://github.com/jtheoof/swappy/issues/91 without users having to modify their local gtk css configurations.

BTW, I'm really liking swappy: IMO it has just the right balance of ease of use vs features. Thanks for the great software.