### PR TITLE
Added option to draw straight lines, without arrow head

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ custom_color=rgba(193,125,17,1)
 - `r`: Switch to Rectangle
 - `o`: Switch to Ellipse
 - `a`: Switch to Arrow
+- `l`: Switch to Line
 - `d`: Switch to Blur (`d` stands for droplet)
 
 <hr>

--- a/include/application.h
+++ b/include/application.h
@@ -33,6 +33,7 @@ void text_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void rectangle_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void ellipse_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void arrow_clicked_handler(GtkWidget *widget, struct swappy_state *state);
+void line_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void blur_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 
 void copy_clicked_handler(GtkWidget *widget, struct swappy_state *state);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -20,6 +20,7 @@ enum swappy_paint_type {
   SWAPPY_PAINT_MODE_RECTANGLE, /* Rectangle shapes */
   SWAPPY_PAINT_MODE_ELLIPSE,   /* Ellipse shapes */
   SWAPPY_PAINT_MODE_ARROW,     /* Arrow shapes */
+  SWAPPY_PAINT_MODE_LINE,      /* Straight lines */
   SWAPPY_PAINT_MODE_BLUR,      /* Blur mode */
 };
 
@@ -127,6 +128,7 @@ struct swappy_state_ui {
   GtkRadioButton *rectangle;
   GtkRadioButton *ellipse;
   GtkRadioButton *arrow;
+  GtkRadioButton *line;
   GtkRadioButton *blur;
 
   GtkRadioButton *red;

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -153,12 +153,24 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="no">D</property>
+                        <property name="label" translatable="no">L</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="no">D</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                   </object>
@@ -256,6 +268,22 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkRadioButton" id="line">
+                        <property name="label" translatable="no">󰕞</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">False</property>
+                        <property name="group">brush</property>
+                        <signal name="clicked" handler="line_clicked_handler" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkRadioButton" id="blur">
                         <property name="label" translatable="no"></property>
                         <property name="visible">True</property>
@@ -268,7 +296,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">5</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                     <style>

--- a/src/application.c
+++ b/src/application.c
@@ -156,6 +156,11 @@ static void switch_mode_to_arrow(struct swappy_state *state) {
   gtk_widget_set_sensitive(GTK_WIDGET(state->ui->fill_shape), false);
 }
 
+static void switch_mode_to_line(struct swappy_state *state) {
+  state->mode = SWAPPY_PAINT_MODE_LINE;
+  gtk_widget_set_sensitive(GTK_WIDGET(state->ui->fill_shape), false);
+}
+
 static void switch_mode_to_blur(struct swappy_state *state) {
   state->mode = SWAPPY_PAINT_MODE_BLUR;
   gtk_widget_set_sensitive(GTK_WIDGET(state->ui->fill_shape), false);
@@ -302,6 +307,10 @@ void arrow_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
   switch_mode_to_arrow(state);
 }
 
+void line_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
+  switch_mode_to_line(state);
+}
+
 void blur_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
   switch_mode_to_blur(state);
 }
@@ -397,6 +406,10 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
       case GDK_KEY_a:
         switch_mode_to_arrow(state);
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->arrow), true);
+        break;
+      case GDK_KEY_l:
+        switch_mode_to_line(state);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->line), true);
         break;
       case GDK_KEY_d:
         switch_mode_to_blur(state);
@@ -524,6 +537,7 @@ void draw_area_button_press_handler(GtkWidget *widget, GdkEventButton *event,
       case SWAPPY_PAINT_MODE_RECTANGLE:
       case SWAPPY_PAINT_MODE_ELLIPSE:
       case SWAPPY_PAINT_MODE_ARROW:
+      case SWAPPY_PAINT_MODE_LINE:
       case SWAPPY_PAINT_MODE_TEXT:
         paint_add_temporary(state, x, y, state->mode);
         render_state(state);
@@ -554,6 +568,7 @@ void draw_area_motion_notify_handler(GtkWidget *widget, GdkEventMotion *event,
     case SWAPPY_PAINT_MODE_RECTANGLE:
     case SWAPPY_PAINT_MODE_ELLIPSE:
     case SWAPPY_PAINT_MODE_ARROW:
+    case SWAPPY_PAINT_MODE_LINE:
       if (is_button1_pressed) {
         paint_update_temporary_shape(state, x, y, is_control_pressed);
         render_state(state);
@@ -582,6 +597,7 @@ void draw_area_button_release_handler(GtkWidget *widget, GdkEventButton *event,
     case SWAPPY_PAINT_MODE_RECTANGLE:
     case SWAPPY_PAINT_MODE_ELLIPSE:
     case SWAPPY_PAINT_MODE_ARROW:
+    case SWAPPY_PAINT_MODE_LINE:
       commit_state(state);
       break;
     case SWAPPY_PAINT_MODE_TEXT:
@@ -765,6 +781,8 @@ static bool load_layout(struct swappy_state *state) {
       GTK_RADIO_BUTTON(gtk_builder_get_object(builder, "ellipse"));
   GtkRadioButton *arrow =
       GTK_RADIO_BUTTON(gtk_builder_get_object(builder, "arrow"));
+  GtkRadioButton *line =
+      GTK_RADIO_BUTTON(gtk_builder_get_object(builder, "line"));
   GtkRadioButton *blur =
       GTK_RADIO_BUTTON(gtk_builder_get_object(builder, "blur"));
 
@@ -795,6 +813,7 @@ static bool load_layout(struct swappy_state *state) {
   state->ui->rectangle = rectangle;
   state->ui->ellipse = ellipse;
   state->ui->arrow = arrow;
+  state->ui->line = line;
   state->ui->blur = blur;
   state->ui->area = area;
   state->ui->window = window;
@@ -830,6 +849,10 @@ static void set_paint_mode(struct swappy_state *state) {
       break;
     case SWAPPY_PAINT_MODE_ARROW:
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->arrow), true);
+      gtk_widget_set_sensitive(GTK_WIDGET(state->ui->fill_shape), false);
+      break;
+    case SWAPPY_PAINT_MODE_LINE:
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(state->ui->line), true);
       gtk_widget_set_sensitive(GTK_WIDGET(state->ui->fill_shape), false);
       break;
     case SWAPPY_PAINT_MODE_BLUR:

--- a/src/config.c
+++ b/src/config.c
@@ -213,6 +213,8 @@ static void load_config_from_file(struct swappy_config *config,
       config->paint_mode = SWAPPY_PAINT_MODE_ELLIPSE;
     } else if (g_ascii_strcasecmp(paint_mode, "arrow") == 0) {
       config->paint_mode = SWAPPY_PAINT_MODE_ARROW;
+    } else if (g_ascii_strcasecmp(paint_mode, "line") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_LINE;
     } else if (g_ascii_strcasecmp(paint_mode, "blur") == 0) {
       config->paint_mode = SWAPPY_PAINT_MODE_BLUR;
     } else {

--- a/src/paint.c
+++ b/src/paint.c
@@ -108,6 +108,7 @@ void paint_add_temporary(struct swappy_state *state, double x, double y,
     case SWAPPY_PAINT_MODE_RECTANGLE:
     case SWAPPY_PAINT_MODE_ELLIPSE:
     case SWAPPY_PAINT_MODE_ARROW:
+    case SWAPPY_PAINT_MODE_LINE:
       paint->can_draw = false;  // need `to` vector
 
       paint->content.shape.from.x = x;
@@ -181,6 +182,7 @@ void paint_update_temporary_shape(struct swappy_state *state, double x,
       paint->content.shape.to.y = y;
       break;
     case SWAPPY_PAINT_MODE_ARROW:
+    case SWAPPY_PAINT_MODE_LINE:
       paint->can_draw = true;  // all set
 
       paint->content.shape.to.x = x;

--- a/src/render.c
+++ b/src/render.c
@@ -281,6 +281,40 @@ static void render_shape_arrow(cairo_t *cr, struct swappy_paint_shape shape) {
   cairo_restore(cr);
 }
 
+static void render_shape_line(cairo_t *cr, struct swappy_paint_shape shape) {
+  cairo_set_source_rgba(cr, shape.r, shape.g, shape.b, shape.a);
+  cairo_set_line_width(cr, shape.w);
+
+  double ftx = shape.to.x - shape.from.x;
+  double fty = shape.to.y - shape.from.y;
+  double ftn = sqrt(ftx * ftx + fty * fty);
+
+  double scaling_factor = shape.w / 4;
+
+  double alpha = G_PI / 6;
+  double ta = 5 * alpha;
+  double xc = ftn - fabs(cos(ta)) * scaling_factor;
+
+  if (xc < DBL_EPSILON) {
+    xc = 0;
+  }
+
+  if (ftn < DBL_EPSILON) {
+    return;
+  }
+
+  double theta = copysign(1.0, fty) * acos(ftx / ftn);
+
+  // Draw line
+  cairo_save(cr);
+  cairo_translate(cr, shape.from.x, shape.from.y);
+  cairo_rotate(cr, theta);
+  cairo_move_to(cr, 0, 0);
+  cairo_line_to(cr, xc, 0);
+  cairo_stroke(cr);
+  cairo_restore(cr);
+}
+
 static void render_shape_ellipse(cairo_t *cr, struct swappy_paint_shape shape) {
   double x = fabs(shape.from.x - shape.to.x);
   double y = fabs(shape.from.y - shape.to.y);
@@ -372,6 +406,9 @@ static void render_shape(cairo_t *cr, struct swappy_paint_shape shape) {
       break;
     case SWAPPY_PAINT_MODE_ARROW:
       render_shape_arrow(cr, shape);
+      break;
+    case SWAPPY_PAINT_MODE_LINE:
+      render_shape_line(cr, shape);
       break;
     default:
       break;
@@ -484,6 +521,7 @@ static void render_paint(cairo_t *cr, struct swappy_paint *paint) {
     case SWAPPY_PAINT_MODE_RECTANGLE:
     case SWAPPY_PAINT_MODE_ELLIPSE:
     case SWAPPY_PAINT_MODE_ARROW:
+    case SWAPPY_PAINT_MODE_LINE:
       render_shape(cr, paint->content.shape);
       break;
     case SWAPPY_PAINT_MODE_TEXT:

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -97,6 +97,7 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 - *r*: Switch to Rectangle
 - *o*: Switch to Ellipse
 - *a*: Switch to Arrow
+- *l*: Switch to Line
 - *d*: Switch to Blur (d stands for droplet)
 
 - *R*: Use Red Color


### PR DESCRIPTION
`l`: switch to Straight Lines mode
Button has been added to visually enable this mode with the mouse.

Allows to draw straight lines without the pointy end of the arrows. Arrow mode left untouched.

![new-swappy](https://github.com/user-attachments/assets/f2018911-87f1-4117-9dfc-d99bdcfd51a4)
