### PR TITLE
feat(ui): add cropping tool (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ transparency=50
 - `line_size` is the default line size (must be between 1 and 50)
 - `text_size` is the default text size (must be between 10 and 50)
 - `text_font` is the font used to render text, its format is pango friendly
-- `paint_mode` is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
+- `paint_mode` is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur|crop, matching is case-insensitive)
 - `early_exit` is used to make the application exit after saving the picture or copying it to the clipboard
 - `fill_shape` is used to toggle shape filling (for the rectangle and ellipsis tools) on or off upon startup
 - `auto_save` is used to toggle auto saving of final buffer to `save_dir` upon exit
@@ -84,6 +84,7 @@ transparency=50
 - `c` `o`: Switch to Ellipse (Circle)
 - `a`: Switch to Arrow
 - `d`: Switch to Blur (`d` stands for droplet)
+- `z`: Switch to Crop
 
 <hr>
 
@@ -100,7 +101,9 @@ transparency=50
 
 <hr>
 
-- `Ctrl`: Center Shape (Rectangle & Ellipse) based on draw start
+- `Ctrl`:
+	- Rectangle & Ellipse: Center Shape based on draw start
+	- Crop: Draw a new crop rectangle instead of changing the existing one
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ transparency=50
 
 <hr>
 
-- `Ctrl`:
-	- Rectangle & Ellipse: Center Shape based on draw start
-	- Crop: Draw a new crop rectangle instead of changing the existing one
+- `Ctrl`: Center Shape (Rectangle & Ellipse) based on draw start
 
 <hr>
 

--- a/include/application.h
+++ b/include/application.h
@@ -34,6 +34,7 @@ void rectangle_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void ellipse_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void arrow_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void blur_clicked_handler(GtkWidget *widget, struct swappy_state *state);
+void crop_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 
 void copy_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void save_clicked_handler(GtkWidget *widget, struct swappy_state *state);

--- a/include/paint.h
+++ b/include/paint.h
@@ -14,16 +14,9 @@ void paint_update_temporary_str(struct swappy_state *state, char *event);
 void paint_update_temporary_text_clip(struct swappy_state *state, gdouble x,
                                       gdouble y);
 void paint_commit_temporary(struct swappy_state *state);
-
-void paint_get_crop_resize(enum swappy_resize *out_resize_x,
-                           enum swappy_resize *out_resize_y,
-                           const struct swappy_state *state, double x,
-                           double y);
-bool paint_crop_should_recreate(const struct swappy_crop *crop);
-void paint_start_crop(struct swappy_state *state, double x, double y,
-                      gboolean recreate_requested);
-void paint_update_crop(struct swappy_state *state, double delta_x,
-                       double delta_y);
+void paint_get_last_crop(struct swappy_point *out_min,
+                         struct swappy_point *out_max,
+                         const struct swappy_state *state);
 
 void paint_free(gpointer data);
 void paint_free_all(struct swappy_state *state);

--- a/include/paint.h
+++ b/include/paint.h
@@ -15,6 +15,16 @@ void paint_update_temporary_text_clip(struct swappy_state *state, gdouble x,
                                       gdouble y);
 void paint_commit_temporary(struct swappy_state *state);
 
+void paint_get_crop_resize(enum swappy_resize *out_resize_x,
+                           enum swappy_resize *out_resize_y,
+                           const struct swappy_state *state, double x,
+                           double y);
+bool paint_crop_should_recreate(const struct swappy_crop *crop);
+void paint_start_crop(struct swappy_state *state, double x, double y,
+                      gboolean recreate_requested);
+void paint_update_crop(struct swappy_state *state, double delta_x,
+                       double delta_y);
+
 void paint_free(gpointer data);
 void paint_free_all(struct swappy_state *state);
 void paint_free_list(GList **list);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -24,6 +24,7 @@ enum swappy_paint_type {
   SWAPPY_PAINT_MODE_ELLIPSE,   /* Ellipse shapes */
   SWAPPY_PAINT_MODE_ARROW,     /* Arrow shapes */
   SWAPPY_PAINT_MODE_BLUR,      /* Blur mode */
+  SWAPPY_PAINT_MODE_CROP,      /* Crop mode */
 };
 
 enum swappy_paint_shape_operation {
@@ -34,6 +35,13 @@ enum swappy_paint_shape_operation {
 enum swappy_text_mode {
   SWAPPY_TEXT_MODE_EDIT = 0,
   SWAPPY_TEXT_MODE_DONE,
+};
+
+enum swappy_resize {
+  SWAPPY_RESIZE_NONE = 0,   /* No resize along the axis. */
+  SWAPPY_RESIZE_LOW = -1,   /* Changing the lower bound on the axis. */
+  SWAPPY_RESIZE_HIGH = +1,  /* Changing the higher bound on the axis. */
+  SWAPPY_RESIZE_BOTH = 127, /* Moving both bounds on the axis. */
 };
 
 struct swappy_point {
@@ -119,6 +127,7 @@ struct swappy_state_ui {
   GtkIMContext *im_context;
 
   GtkWidget *area;
+  GtkWidget *visual_area;
 
   GtkToggleButton *panel_toggle_button;
 
@@ -134,6 +143,7 @@ struct swappy_state_ui {
   GtkRadioButton *ellipse;
   GtkRadioButton *arrow;
   GtkRadioButton *blur;
+  GtkRadioButton *crop;
 
   GtkRadioButton *red;
   GtkRadioButton *green;
@@ -168,6 +178,16 @@ struct swappy_config {
   char *custom_color;
 };
 
+struct swappy_crop {
+  uint32_t left_x;
+  uint32_t top_y;
+  uint32_t right_x;
+  uint32_t bottom_y;
+
+  enum swappy_resize resize_x;
+  enum swappy_resize resize_y;
+};
+
 struct swappy_state {
   GtkApplication *app;
 
@@ -177,6 +197,13 @@ struct swappy_state {
   GdkPixbuf *original_image;
   cairo_surface_t *original_image_surface;
   cairo_surface_t *rendering_surface;
+  cairo_surface_t *visual_surface;
+
+  double last_mouse_x;
+  double last_mouse_y;
+
+  struct swappy_crop crop;
+  gboolean crop_ever_changed;
 
   gdouble scaling_factor;
 

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -37,13 +37,6 @@ enum swappy_text_mode {
   SWAPPY_TEXT_MODE_DONE,
 };
 
-enum swappy_resize {
-  SWAPPY_RESIZE_NONE = 0,   /* No resize along the axis. */
-  SWAPPY_RESIZE_LOW = -1,   /* Changing the lower bound on the axis. */
-  SWAPPY_RESIZE_HIGH = +1,  /* Changing the higher bound on the axis. */
-  SWAPPY_RESIZE_BOTH = 127, /* Moving both bounds on the axis. */
-};
-
 struct swappy_point {
   gdouble x;
   gdouble y;
@@ -91,6 +84,12 @@ struct swappy_paint_blur {
   cairo_surface_t *surface;
 };
 
+struct swappy_paint_crop {
+  struct swappy_point from;
+  struct swappy_point to;
+  struct swappy_paint *prev_crop;
+};
+
 struct swappy_paint {
   enum swappy_paint_type type;
   bool can_draw;
@@ -100,6 +99,7 @@ struct swappy_paint {
     struct swappy_paint_shape shape;
     struct swappy_paint_text text;
     struct swappy_paint_blur blur;
+    struct swappy_paint_crop crop;
   } content;
 };
 
@@ -178,16 +178,6 @@ struct swappy_config {
   char *custom_color;
 };
 
-struct swappy_crop {
-  uint32_t left_x;
-  uint32_t top_y;
-  uint32_t right_x;
-  uint32_t bottom_y;
-
-  enum swappy_resize resize_x;
-  enum swappy_resize resize_y;
-};
-
 struct swappy_state {
   GtkApplication *app;
 
@@ -198,12 +188,6 @@ struct swappy_state {
   cairo_surface_t *original_image_surface;
   cairo_surface_t *rendering_surface;
   cairo_surface_t *visual_surface;
-
-  double last_mouse_x;
-  double last_mouse_y;
-
-  struct swappy_crop crop;
-  gboolean crop_ever_changed;
 
   gdouble scaling_factor;
 
@@ -221,6 +205,7 @@ struct swappy_state {
   GList *paints;
   GList *redo_paints;
   struct swappy_paint *temp_paint;
+  struct swappy_paint *last_crop;
 
   struct swappy_state_settings settings;
 

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -170,7 +170,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="no">C</property>
+                        <property name="label" translatable="no">Z</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -767,7 +767,7 @@
                     <property name="margin_right">10</property>
                     <property name="margin_top">10</property>
                     <property name="margin_bottom">10</property>
-                    <signal name="draw" handler="crop_area_handler" swapped="no"/>
+                    <signal name="draw" handler="visual_area_handler" swapped="no"/>
                   </object>
                 </child>
               </object>

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -166,6 +166,18 @@
                         <property name="position">5</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="no">C</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -274,6 +286,22 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="crop">
+                        <property name="label" translatable="no"></property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">False</property>
+                        <property name="group">brush</property>
+                        <signal name="clicked" handler="crop_clicked_handler" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                     <style>
@@ -729,6 +757,17 @@
                     <signal name="configure-event" handler="draw_area_configure_handler" swapped="no"/>
                     <signal name="draw" handler="draw_area_handler" swapped="no"/>
                     <signal name="motion-notify-event" handler="draw_area_motion_notify_handler" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkDrawingArea" id="visual-area">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">10</property>
+                    <property name="margin_right">10</property>
+                    <property name="margin_top">10</property>
+                    <property name="margin_bottom">10</property>
+                    <signal name="draw" handler="crop_area_handler" swapped="no"/>
                   </object>
                 </child>
               </object>

--- a/src/config.c
+++ b/src/config.c
@@ -236,6 +236,8 @@ static void load_config_from_file(struct swappy_config *config,
       config->paint_mode = SWAPPY_PAINT_MODE_ARROW;
     } else if (g_ascii_strcasecmp(paint_mode, "blur") == 0) {
       config->paint_mode = SWAPPY_PAINT_MODE_BLUR;
+    } else if (g_ascii_strcasecmp(paint_mode, "crop") == 0) {
+      config->paint_mode = SWAPPY_PAINT_MODE_CROP;
     } else {
       g_warning(
           "paint_mode is not a valid value: %s - see man page for details",

--- a/src/paint.c
+++ b/src/paint.c
@@ -316,3 +316,134 @@ void paint_commit_temporary(struct swappy_state *state) {
   // because it's now part of the GList.
   state->temp_paint = NULL;
 }
+
+void paint_get_crop_resize(enum swappy_resize *out_resize_x,
+                           enum swappy_resize *out_resize_y,
+                           const struct swappy_state *state, double x,
+                           double y) {
+  const struct swappy_crop *crop = &state->crop;
+  const double part_size = 30 / state->scaling_factor;
+
+  if (x < crop->left_x - part_size || x > crop->right_x + part_size ||
+      y < crop->top_y - part_size || y > crop->bottom_y + part_size) {
+    *out_resize_x = SWAPPY_RESIZE_NONE;
+    *out_resize_y = SWAPPY_RESIZE_NONE;
+    return;
+  }
+
+  if (x < crop->left_x + part_size)
+    *out_resize_x = SWAPPY_RESIZE_LOW;
+  else if (x > crop->right_x - part_size)
+    *out_resize_x = SWAPPY_RESIZE_HIGH;
+  else if (x >= crop->left_x && x <= crop->right_x)
+    *out_resize_x = SWAPPY_RESIZE_BOTH;
+  else
+    *out_resize_x = SWAPPY_RESIZE_NONE;
+
+  if (y < crop->top_y + part_size)
+    *out_resize_y = SWAPPY_RESIZE_LOW;
+  else if (y > crop->bottom_y - part_size)
+    *out_resize_y = SWAPPY_RESIZE_HIGH;
+  else if (y >= crop->top_y && y <= crop->bottom_y)
+    *out_resize_y = SWAPPY_RESIZE_BOTH;
+  else
+    *out_resize_y = SWAPPY_RESIZE_NONE;
+
+  if (*out_resize_x == SWAPPY_RESIZE_BOTH &&
+      *out_resize_y != SWAPPY_RESIZE_BOTH)
+    *out_resize_x = SWAPPY_RESIZE_NONE;
+  if (*out_resize_y == SWAPPY_RESIZE_BOTH &&
+      *out_resize_x != SWAPPY_RESIZE_BOTH)
+    *out_resize_y = SWAPPY_RESIZE_NONE;
+}
+
+void paint_start_crop(struct swappy_state *state, double x, double y,
+                      gboolean recreate_requested) {
+  if (!recreate_requested) {
+    paint_get_crop_resize(&state->crop.resize_x, &state->crop.resize_y, state,
+                          x, y);
+
+    if (state->crop.resize_x || state->crop.resize_y) return;
+  }
+
+  state->crop.left_x = x;
+  state->crop.right_x = x;
+  state->crop.top_y = y;
+  state->crop.bottom_y = y;
+
+  state->crop.resize_x = SWAPPY_RESIZE_HIGH;
+  state->crop.resize_y = SWAPPY_RESIZE_HIGH;
+}
+
+static inline bool u32_add_clamped(uint32_t *val, double to_add, uint32_t max) {
+  if (*val + to_add > max) {
+    *val = max;
+    return true;
+  } else if (to_add < 0 && *val < -to_add) {
+    *val = 0;
+    return true;
+  } else {
+    *val += to_add;
+    return false;
+  }
+}
+
+void paint_update_crop(struct swappy_state *state, double delta_x,
+                       double delta_y) {
+  struct swappy_crop *crop = &state->crop;
+  double iw = cairo_image_surface_get_width(state->rendering_surface);
+  double ih = cairo_image_surface_get_height(state->rendering_surface);
+
+  switch (crop->resize_x) {
+    case SWAPPY_RESIZE_NONE:
+      break;
+    case SWAPPY_RESIZE_LOW:
+      u32_add_clamped(&crop->left_x, delta_x, iw);
+      break;
+    case SWAPPY_RESIZE_HIGH:
+      u32_add_clamped(&crop->right_x, delta_x, iw);
+      break;
+    case SWAPPY_RESIZE_BOTH: {
+      uint32_t width = crop->right_x - crop->left_x;
+      if (u32_add_clamped(&crop->left_x, delta_x, iw)) {
+        crop->right_x = crop->left_x + width;
+      } else if (u32_add_clamped(&crop->right_x, delta_x, iw)) {
+        crop->left_x = crop->right_x - width;
+      }
+      break;
+    }
+  }
+  switch (crop->resize_y) {
+    case SWAPPY_RESIZE_NONE:
+      break;
+    case SWAPPY_RESIZE_LOW:
+      u32_add_clamped(&crop->top_y, delta_y, ih);
+      break;
+    case SWAPPY_RESIZE_HIGH:
+      u32_add_clamped(&crop->bottom_y, delta_y, ih);
+      break;
+    case SWAPPY_RESIZE_BOTH: {
+      uint32_t height = crop->bottom_y - crop->top_y;
+      if (u32_add_clamped(&crop->top_y, delta_y, ih)) {
+        crop->bottom_y = crop->top_y + height;
+      } else if (u32_add_clamped(&crop->bottom_y, delta_y, ih)) {
+        crop->top_y = crop->bottom_y - height;
+      }
+      break;
+    }
+  }
+
+  uint32_t k;
+  if (crop->left_x > crop->right_x) {
+    k = crop->left_x;
+    crop->left_x = crop->right_x;
+    crop->right_x = k;
+    crop->resize_x = -crop->resize_x;
+  }
+  if (crop->top_y > crop->bottom_y) {
+    k = crop->top_y;
+    crop->top_y = crop->bottom_y;
+    crop->bottom_y = k;
+    crop->resize_y = -crop->resize_y;
+  }
+}

--- a/src/pixbuf.c
+++ b/src/pixbuf.c
@@ -3,12 +3,15 @@
 #include <cairo/cairo.h>
 #include <gio/gunixoutputstream.h>
 
+#include "paint.h"
+
 GdkPixbuf *pixbuf_get_from_state(struct swappy_state *state) {
-  guint width = state->crop.right_x - state->crop.left_x;
-  guint height = state->crop.bottom_y - state->crop.top_y;
-  GdkPixbuf *pixbuf =
-      gdk_pixbuf_get_from_surface(state->rendering_surface, state->crop.left_x,
-                                  state->crop.top_y, width, height);
+  struct swappy_point min, max;
+  paint_get_last_crop(&min, &max, state);
+  guint width = max.x - min.x;
+  guint height = max.y - min.y;
+  GdkPixbuf *pixbuf = gdk_pixbuf_get_from_surface(state->rendering_surface,
+                                                  min.x, min.y, width, height);
 
   return pixbuf;
 }
@@ -148,13 +151,6 @@ finish:
     state->visual_surface = NULL;
   }
   state->visual_surface = visual_surface;
-
-  state->crop = (struct swappy_crop){
-      .left_x = 0,
-      .top_y = 0,
-      .right_x = image_width,
-      .bottom_y = image_height,
-  };
 
   g_free(alloc);
 }

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -78,7 +78,7 @@ The following lines can be used as swappy's default:
 - *line_size* is the default line size (must be between 1 and 50)
 - *text_size* is the default text size (must be between 10 and 50)
 - *text_font* is the font used to render text, its format is pango friendly
-- *paint_mode* is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur, matching is case-insensitive)
+- *paint_mode* is the mode activated at application start (must be one of: brush|text|rectangle|ellipse|arrow|blur|crop, matching is case-insensitive)
 - *early_exit* is used to make the application exit after saving the picture or copying it to the clipboard
 - *fill_shape* is used to toggle shape filling (for the rectangle and ellipsis tools) on or off upon startup
 - *auto_save* is used to toggle auto saving of final buffer to *save_dir* upon exit
@@ -102,6 +102,7 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 - `c` `o`: Switch to Ellipse (Circle)
 - *a*: Switch to Arrow
 - *d*: Switch to Blur (d stands for droplet)
+- *c*: Switch to Crop
 
 - *R*: Use Red Color
 - *G*: Use Green Color
@@ -116,7 +117,9 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 
 ## MODIFIERS
 
-- *Ctrl*: Center Shape (Rectangle & Ellipse) based on draw start
+- *Ctrl*:
+	- Rectangle & Ellipse: Center Shape based on draw start
+	- Crop: Draw a new crop rectangle instead of changing the existing one
 
 ## HEADER BAR
 

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -97,12 +97,12 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 ## PAINT MODE
 
 - *b*: Switch to Brush
-- `e` `t`: Switch to Text (Editor)
-- `r` `s`: Switch to Rectangle (Square)
-- `c` `o`: Switch to Ellipse (Circle)
+- *e* *t*: Switch to Text (Editor)
+- *r* *s*: Switch to Rectangle (Square)
+- *c* *o*: Switch to Ellipse (Circle)
 - *a*: Switch to Arrow
 - *d*: Switch to Blur (d stands for droplet)
-- *c*: Switch to Crop
+- *z*: Switch to Crop
 
 - *R*: Use Red Color
 - *G*: Use Green Color
@@ -113,13 +113,11 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 - *Equal*: Reset Stroke Size
 - *f*: Toggle Shape Filling
 - *T*: Toggle Transparency
-- `x` `k`: Clear Paints (cannot be undone)
+- *x* *k*: Clear Paints (cannot be undone)
 
 ## MODIFIERS
 
-- *Ctrl*:
-	- Rectangle & Ellipse: Center Shape based on draw start
-	- Crop: Draw a new crop rectangle instead of changing the existing one
+- *Ctrl*: Center Shape (Rectangle & Ellipse) based on draw start
 
 ## HEADER BAR
 


### PR DESCRIPTION
Closes #55 
Closes #155


### TODO:

- [x] ~~Better cursor position handling: make it regions around the crop rectangle's edges, not fractions of the sides. Also probably let the regions be slightly outside of the rectangle as well~~
- [x] ~~Move the crop rectangle by dragging it by its middle~~
    - [x] ~~Do not resize the rectangle while clamping~~
- [x] Fix semi-transparent backdrop rendering when the image is landscape (~~how did that happen?~~ – ah, a very trivial typo, oops)
- [x] Make the cropping tool interact with the built-in undo/redo
- [x] Add the ability to reset the crop
- [x] Update all the docs and labels to reflect the new keybind (conflicted with #183 merged in the meantime)