### PR TITLE
support OCR by command  tesseract 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ auto_save=false
 custom_color=rgba(193,125,17,1)
 transparent=false
 transparency=50
+# cmd for OCR, args split by ";", %s is replaced by image path
+# tesseract input.png  -
+ocr_cmd=tesseract;%s;-
 ```
 
 - `save_dir` is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -70,6 +73,7 @@ transparency=50
 - `custom_color` is used to set a default value for the custom color
 - `transparency` is used to set transparency of everything that is drawn during startup
 - `transparent` is used to toggle transparency during startup
+- `ocr_cmd` is used to support OCR,args split by ";", %s is replaced by image path 
 
 
 ## Keyboard Shortcuts

--- a/include/clipboard.h
+++ b/include/clipboard.h
@@ -3,3 +3,4 @@
 #include "swappy.h"
 
 bool clipboard_copy_drawing_area_to_selection(struct swappy_state *state);
+bool clipboard_copy_to_selection(struct swappy_state *state);

--- a/include/ocr.h
+++ b/include/ocr.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "swappy.h"
+
+char *execute_ocr_command(char **ocr_cmd, gsize ocr_cmd_len, char *file);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -149,6 +149,7 @@ struct swappy_state_ui {
 
   GtkToggleButton *fill_shape;
   GtkToggleButton *transparent;
+  GtkTextView *ocr_text;
 };
 
 struct swappy_config {
@@ -166,6 +167,8 @@ struct swappy_config {
   gboolean early_exit;
   gboolean auto_save;
   char *custom_color;
+  char **ocr_cmd;
+  gsize ocr_cmd_len;
 };
 
 struct swappy_state {

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ executable(
 		'src/config.c',
 		'src/clipboard.c',
 		'src/file.c',
+		'src/ocr.c',
 		'src/paint.c',
 		'src/pixbuf.c',
 		'src/render.c',

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -703,6 +703,28 @@
                     <property name="position">6</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <child>
+                      <object class="GtkTextView" id="ocr_text">
+                        <property name="visible">True</property>
+                        <property name="margin">5</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap_mode">word</property>
+                        <property name="editable">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">7</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="resize">False</property>

--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,8 @@ static void load_config_from_file(struct swappy_config *config,
   gboolean fill_shape;
   gboolean auto_save;
   gchar *custom_color = NULL;
+  gchar **ocr_cmd = NULL;
+  gsize ocr_cmd_len = 0;
   gboolean transparent;
   GError *error = NULL;
 
@@ -286,6 +288,17 @@ static void load_config_from_file(struct swappy_config *config,
     g_error_free(error);
     error = NULL;
   }
+  ocr_cmd =
+      g_key_file_get_string_list(gkf, group, "ocr_cmd", &ocr_cmd_len, &error);
+  if (error == NULL) {
+    config->ocr_cmd_len = ocr_cmd_len;
+    config->ocr_cmd = ocr_cmd;
+    printf("ocr_cmd_len: %zu\n", ocr_cmd_len);
+  } else {
+    g_info("ocr_cmd is missing in %s (%s)", file, error->message);
+    g_error_free(error);
+    error = NULL;
+  }
 
   g_key_file_free(gkf);
 }
@@ -308,6 +321,9 @@ static void load_default_config(struct swappy_config *config) {
   config->custom_color = g_strdup(CONFIG_CUSTOM_COLOR_DEFAULT);
   config->transparent = CONFIG_TRANSPARENT_DEFAULT;
   config->transparency = CONFIG_TRANSPARENCY_DEFAULT;
+  config->ocr_cmd = NULL;
+  config->ocr_cmd_len = 0;
+  return;
 }
 
 void config_load(struct swappy_state *state) {

--- a/src/ocr.c
+++ b/src/ocr.c
@@ -1,0 +1,66 @@
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// replace %s in str with file
+static char *replace_string(const char *str, const char *file) {
+  GString *result = g_string_new(NULL);
+  const char *p = str;
+  const char *found;
+  while ((found = strstr(p, "%s")) != NULL) {
+    g_string_append_len(result, p, found - p);
+    g_string_append(result, file);
+    p = found + 2;
+  }
+  g_string_append(result, p);
+  return g_string_free(result, FALSE);
+}
+
+char *execute_ocr_command(char **ocr_cmd, gsize ocr_cmd_len, char *file) {
+  GError *error = NULL;
+  char *standard_output = NULL;
+  char *standard_error = NULL;
+  int exit_status = 0;
+  GPtrArray *args_array = g_ptr_array_new();
+
+  for (size_t i = 0; i < ocr_cmd_len; i++) {
+    const char *arg = ocr_cmd[i];
+    if (strstr(arg, "%s") != NULL) {
+      char *new_arg = replace_string(arg, file);
+      g_ptr_array_add(args_array, new_arg);
+    } else {
+      g_ptr_array_add(args_array, g_strdup(arg));
+    }
+  }
+  g_ptr_array_add(args_array, NULL);
+
+  gboolean success = g_spawn_sync(
+      NULL, (char **)args_array->pdata, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL,
+      &standard_output, &standard_error, &exit_status, &error);
+
+  for (size_t i = 0; i < args_array->len - 1; i++) {
+    g_free(g_ptr_array_index(args_array, i));
+  }
+  g_ptr_array_free(args_array, TRUE);
+
+  if (!success) {
+    g_printerr("execute_ocr_command: %s\n", error->message);
+    g_error_free(error);
+    g_free(standard_output);
+    g_free(standard_error);
+    return NULL;
+  }
+
+  if (exit_status != 0) {
+    g_printerr("execute_ocr_command: exit_status:%d\n", exit_status);
+    if (standard_error != NULL) {
+      g_printerr("stderr: %s\n", standard_error);
+    }
+    g_free(standard_output);
+    g_free(standard_error);
+    return NULL;
+  }
+  g_free(standard_error);
+  return standard_output;  // you should free this outside
+}

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -70,6 +70,9 @@ The following lines can be used as swappy's default:
 	custom_color=rgba(192,125,17,1)
 	transparent=false
 	transparency=50
+    # cmd for OCR, args split by ";", %s for image path
+    # tesseract input.png  -
+    ocr_cmd=tesseract;%s;-
 ```
 
 - *save_dir* is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails


### PR DESCRIPTION
<img width="1958" height="1266" alt="图片" src="https://github.com/user-attachments/assets/d44c74e2-3e6a-45a7-8091-e83cab1cf036" />
<img width="2092" height="782" alt="图片" src="https://github.com/user-attachments/assets/46276cf1-33f5-46b1-b9d4-729b949b3ff8" />


 `ocr_cmd`is used to support OCR functionality, where arguments are separated by ";", and %s serves as a placeholder that will be replaced by the image path.
a demo config with https://github.com/tesseract-ocr/tesseract :

```
ocr_cmd=tesseract;%s;-
```
`Ctrl-a` select all the text in the GtkTextView 
`Ctrl-c` or the click the  copy button to  copy the selected text .