### PR TITLE
fix(meson): add missing dependency on gio-unix-2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ pango = dependency('pango')
 math = cc.find_library('m')
 gtk = dependency('gtk+-3.0', version: '>=3.20.0')
 gio = dependency('gio-2.0')
+gio_unix = dependency('gio-unix-2.0')
 
 subdir('res')
 subdir('src/po')
@@ -66,6 +67,7 @@ executable(
 		cairo,
 		pango,
 		gio,
+		gio_unix,
 		gtk,
 		math,
 	],


### PR DESCRIPTION
Makes the dependencies factually correct.  This fixes the build on Nix, removing the need for the workaround currently present in nixpkgs.

See also: <https://github.com/NixOS/nixpkgs/issues/36468>