### PR TITLE
Feature: very basic rotation support

### DIFF
--- a/include/application.h
+++ b/include/application.h
@@ -16,6 +16,9 @@ void pane_toggled_handler(GtkWidget *widget, struct swappy_state *state);
 void undo_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 void redo_clicked_handler(GtkWidget *widget, struct swappy_state *state);
 
+void rot_left_clicked_handler(GtkWidget *widget, struct swappy_state *state);
+void rot_right_clicked_handler(GtkWidget *widget, struct swappy_state *state);
+
 gboolean draw_area_handler(GtkWidget *widget, cairo_t *cr,
                            struct swappy_state *state);
 gboolean draw_area_configure_handler(GtkWidget *widget,

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -135,6 +135,10 @@ struct swappy_state_ui {
   GtkRadioButton *arrow;
   GtkRadioButton *blur;
 
+  // Rotation
+  GtkButton *rot_left;
+  GtkButton *rot_right;
+
   GtkRadioButton *red;
   GtkRadioButton *green;
   GtkRadioButton *blue;

--- a/res/swappy.glade
+++ b/res/swappy.glade
@@ -12,6 +12,16 @@
     <property name="can_focus">False</property>
     <property name="icon_name">edit-undo-symbolic</property>
   </object>
+  <object class="GtkImage" id="edit-rot-left">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">object-rotate-left-symbolic</property>
+  </object>
+  <object class="GtkImage" id="edit-rot-right">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">object-rotate-right-symbolic</property>
+  </object>
   <object class="GtkImage" id="img-clear-paints">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -819,6 +829,47 @@
                 <property name="non_homogeneous">True</property>
               </packing>
             </child>
+
+            <child>
+              <object class="GtkButton" id="rot-left-button">
+                <property name="visible">True</property>
+                <property name="sensitive">True</property>
+                <property name="can_focus">False</property>
+                <property name="focus_on_click">False</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Rotate Left</property>
+                <property name="image">edit-rot-left</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="rot_left_clicked_handler" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+                <property name="non_homogeneous">True</property>
+              </packing>
+            </child>
+
+            <child>
+              <object class="GtkButton" id="rot-right-button">
+                <property name="visible">True</property>
+                <property name="sensitive">True</property>
+                <property name="can_focus">False</property>
+                <property name="focus_on_click">False</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Rotate Right</property>
+                <property name="image">edit-rot-right</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="rot_right_clicked_handler" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+                <property name="non_homogeneous">True</property>
+              </packing>
+            </child>
+
             <child>
               <object class="GtkButton" id="clear">
                 <property name="visible">True</property>
@@ -832,7 +883,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">4</property>
                 <property name="secondary">True</property>
                 <property name="non_homogeneous">True</property>
               </packing>


### PR DESCRIPTION
Addresses #115 

* add support for rotating the image (left or right)
    - however, since this is a very basic implementation, it rasterizes the painted annotations like rectangles, ellipses, blur etc. onto the image and then rotates it.
    - the paint vector is cleared and the undo and redo buttons are greyed out.
* add two buttons and setup keybinds `Ctrl+Left` and `Ctrl+Right` for rotating images left and right respectively.