### PR TITLE
feat(application): add `physical` keyboard shortcut mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ auto_save=false
 custom_color=rgba(193,125,17,1)
 transparent=false
 transparency=50
+keyboard_shortcuts=layout
 ```
 
 - `save_dir` is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -70,7 +71,7 @@ transparency=50
 - `custom_color` is used to set a default value for the custom color
 - `transparency` is used to set transparency of everything that is drawn during startup
 - `transparent` is used to toggle transparency during startup
-
+- `keyboard_shortcuts` selects how shortcuts are matched. Use `layout` (default) for the current layout symbols, or `physical` to match the US key positions so shortcuts still work on non-Latin layouts.   
 
 ## Keyboard Shortcuts
 
@@ -110,6 +111,9 @@ transparency=50
 - `Ctrl+c`: Copy to clipboard
 - `Escape` or `q` or `Ctrl+w`: Quit swappy
 
+If you use a non-Latin keyboard layout, set `keyboard_shortcuts=physical` in the
+config file to match the physical US key positions for all shortcuts.
+
 ## Limitations
 
 - **Copy**: If you don't have [wl-clipboard] installed, copy to clipboard won't work if you close swappy (the content of the clipboard is lost). This because GTK 3.24 [has not implemented persistent storage on wayland backend yet](https://gitlab.gnome.org/GNOME/gtk/blob/3.24.13/gdk/wayland/gdkdisplay-wayland.c#L857). We need to do it on the [Wayland level](https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-data-control-unstable-v1.xml), or wait for GTK 4. For now, we use `wl-copy` if installed and revert to `gtk` clipboard if not found.
@@ -136,6 +140,7 @@ Install dependencies (on Arch, name can vary for other distros):
 - gtk
 - glib2
 - scdoc
+- libxkbcommon
 
 Optional dependencies:
 

--- a/example/config
+++ b/example/config
@@ -3,3 +3,4 @@ save_dir=$HOME/Desktop
 line_size=5
 text_size=20
 text_font=sans-serif
+keyboard_shortcuts=layout

--- a/include/config.h
+++ b/include/config.h
@@ -12,6 +12,7 @@
 #define CONFIG_AUTO_SAVE_DEFAULT false
 #define CONFIG_CUSTOM_COLOR_DEFAULT "rgba(193,125,17,1)"
 #define CONFIG_TRANSPARENT_DEFAULT false
+#define CONFIG_KEYBOARD_SHORTCUTS_DEFAULT SWAPPY_KEYBOARD_SHORTCUTS_LAYOUT
 
 void config_load(struct swappy_state *state);
 void config_free(struct swappy_state *state);

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -4,5 +4,5 @@
 
 #include "swappy.h"
 
-guint keyboard_keysym_for_shortcuts(struct swappy_state *state,
+guint keyboard_keysym_for_shortcuts(enum swappy_keyboard_shortcuts mode,
                                     GdkEventKey *event);

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <gtk/gtk.h>
+
+#include "swappy.h"
+
+guint keyboard_keysym_for_shortcuts(struct swappy_state *state,
+                                    GdkEventKey *event);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -36,6 +36,11 @@ enum swappy_text_mode {
   SWAPPY_TEXT_MODE_DONE,
 };
 
+enum swappy_keyboard_shortcuts {
+  SWAPPY_KEYBOARD_SHORTCUTS_LAYOUT = 0,
+  SWAPPY_KEYBOARD_SHORTCUTS_PHYSICAL,
+};
+
 struct swappy_point {
   gdouble x;
   gdouble y;
@@ -166,6 +171,7 @@ struct swappy_config {
   gboolean early_exit;
   gboolean auto_save;
   char *custom_color;
+  enum swappy_keyboard_shortcuts keyboard_shortcuts;
 };
 
 struct swappy_state {

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ pango = dependency('pango')
 math = cc.find_library('m')
 gtk = dependency('gtk+-3.0', version: '>=3.20.0')
 gio = dependency('gio-2.0')
+xkbcommon = dependency('xkbcommon')
 
 subdir('res')
 subdir('src/po')
@@ -57,6 +58,7 @@ executable(
 		'src/config.c',
 		'src/clipboard.c',
 		'src/file.c',
+		'src/keyboard.c',
 		'src/paint.c',
 		'src/pixbuf.c',
 		'src/render.c',
@@ -67,6 +69,7 @@ executable(
 		pango,
 		gio,
 		gtk,
+		xkbcommon,
 		math,
 	],
 	link_args: '-rdynamic',

--- a/src/application.c
+++ b/src/application.c
@@ -9,6 +9,7 @@
 #include "clipboard.h"
 #include "config.h"
 #include "file.h"
+#include "keyboard.h"
 #include "paint.h"
 #include "pixbuf.h"
 #include "render.h"
@@ -424,9 +425,15 @@ static void clipboard_paste_selection(struct swappy_state *state) {
 
 void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
                              struct swappy_state *state) {
+  if (event->keyval == GDK_KEY_Control_L ||
+      event->keyval == GDK_KEY_Control_R) {
+    control_modifier_changed(true, state);
+    return;
+  }
   if (state->temp_paint && state->mode == SWAPPY_PAINT_MODE_TEXT) {
     /* ctrl-v: paste */
-    if (event->state & GDK_CONTROL_MASK && event->keyval == GDK_KEY_v) {
+    if ((event->state & GDK_CONTROL_MASK) &&
+        keyboard_keysym_for_shortcuts(state, event) == GDK_KEY_v) {
       clipboard_paste_selection(state);
     } else {
       paint_update_temporary_text(state, event);
@@ -435,7 +442,7 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
     return;
   }
   if (event->state & GDK_CONTROL_MASK) {
-    switch (event->keyval) {
+    switch (keyboard_keysym_for_shortcuts(state, event)) {
       case GDK_KEY_c:
         clipboard_copy_drawing_area_to_selection(state);
         break;
@@ -459,7 +466,7 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
         break;
     }
   } else {
-    switch (event->keyval) {
+    switch (keyboard_keysym_for_shortcuts(state, event)) {
       case GDK_KEY_Escape:
       case GDK_KEY_q:
         maybe_save_output_file(state);
@@ -524,9 +531,6 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
       case GDK_KEY_plus:
         action_stroke_size_increase(state);
         break;
-      case GDK_KEY_Control_L:
-        control_modifier_changed(true, state);
-        break;
       case GDK_KEY_f:
         action_fill_shape_toggle(state, NULL);
         break;
@@ -541,11 +545,13 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
 
 void window_keyrelease_handler(GtkWidget *widget, GdkEventKey *event,
                                struct swappy_state *state) {
+  if (event->keyval == GDK_KEY_Control_L ||
+      event->keyval == GDK_KEY_Control_R) {
+    control_modifier_changed(false, state);
+    return;
+  }
   if (event->state & GDK_CONTROL_MASK) {
     switch (event->keyval) {
-      case GDK_KEY_Control_L:
-        control_modifier_changed(false, state);
-        break;
       default:
         break;
     }

--- a/src/application.c
+++ b/src/application.c
@@ -425,6 +425,9 @@ static void clipboard_paste_selection(struct swappy_state *state) {
 
 void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
                              struct swappy_state *state) {
+  enum swappy_keyboard_shortcuts shortcuts_mode =
+      state->config->keyboard_shortcuts;
+
   if (event->keyval == GDK_KEY_Control_L ||
       event->keyval == GDK_KEY_Control_R) {
     control_modifier_changed(true, state);
@@ -433,7 +436,7 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
   if (state->temp_paint && state->mode == SWAPPY_PAINT_MODE_TEXT) {
     /* ctrl-v: paste */
     if ((event->state & GDK_CONTROL_MASK) &&
-        keyboard_keysym_for_shortcuts(state, event) == GDK_KEY_v) {
+        keyboard_keysym_for_shortcuts(shortcuts_mode, event) == GDK_KEY_v) {
       clipboard_paste_selection(state);
     } else {
       paint_update_temporary_text(state, event);
@@ -442,7 +445,7 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
     return;
   }
   if (event->state & GDK_CONTROL_MASK) {
-    switch (keyboard_keysym_for_shortcuts(state, event)) {
+    switch (keyboard_keysym_for_shortcuts(shortcuts_mode, event)) {
       case GDK_KEY_c:
         clipboard_copy_drawing_area_to_selection(state);
         break;
@@ -466,7 +469,7 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
         break;
     }
   } else {
-    switch (keyboard_keysym_for_shortcuts(state, event)) {
+    switch (keyboard_keysym_for_shortcuts(shortcuts_mode, event)) {
       case GDK_KEY_Escape:
       case GDK_KEY_q:
         maybe_save_output_file(state);
@@ -548,18 +551,6 @@ void window_keyrelease_handler(GtkWidget *widget, GdkEventKey *event,
   if (event->keyval == GDK_KEY_Control_L ||
       event->keyval == GDK_KEY_Control_R) {
     control_modifier_changed(false, state);
-    return;
-  }
-  if (event->state & GDK_CONTROL_MASK) {
-    switch (event->keyval) {
-      default:
-        break;
-    }
-  } else {
-    switch (event->keyval) {
-      default:
-        break;
-    }
   }
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -26,6 +26,7 @@ static void print_config(struct swappy_config *config) {
   g_info("auto_save: %d", config->auto_save);
   g_info("custom_color: %s", config->custom_color);
   g_info("transparent: %d", config->transparent);
+  g_info("keyboard_shortcuts: %d", config->keyboard_shortcuts);
 }
 
 static char *get_default_save_dir() {
@@ -89,6 +90,7 @@ static void load_config_from_file(struct swappy_config *config,
   gboolean auto_save;
   gchar *custom_color = NULL;
   gboolean transparent;
+  gchar *keyboard_shortcuts = NULL;
   GError *error = NULL;
 
   if (file == NULL) {
@@ -287,6 +289,27 @@ static void load_config_from_file(struct swappy_config *config,
     error = NULL;
   }
 
+  keyboard_shortcuts =
+      g_key_file_get_string(gkf, group, "keyboard_shortcuts", &error);
+
+  if (error == NULL) {
+    if (g_ascii_strcasecmp(keyboard_shortcuts, "layout") == 0) {
+      config->keyboard_shortcuts = SWAPPY_KEYBOARD_SHORTCUTS_LAYOUT;
+    } else if (g_ascii_strcasecmp(keyboard_shortcuts, "physical") == 0) {
+      config->keyboard_shortcuts = SWAPPY_KEYBOARD_SHORTCUTS_PHYSICAL;
+    } else {
+      g_warning(
+          "keyboard_shortcuts is not a valid value: %s - see man page for "
+          "details",
+          keyboard_shortcuts);
+    }
+    g_free(keyboard_shortcuts);
+  } else {
+    g_info("keyboard_shortcuts is missing in %s (%s)", file, error->message);
+    g_error_free(error);
+    error = NULL;
+  }
+
   g_key_file_free(gkf);
 }
 
@@ -308,6 +331,7 @@ static void load_default_config(struct swappy_config *config) {
   config->custom_color = g_strdup(CONFIG_CUSTOM_COLOR_DEFAULT);
   config->transparent = CONFIG_TRANSPARENT_DEFAULT;
   config->transparency = CONFIG_TRANSPARENCY_DEFAULT;
+  config->keyboard_shortcuts = CONFIG_KEYBOARD_SHORTCUTS_DEFAULT;
 }
 
 void config_load(struct swappy_state *state) {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1,0 +1,146 @@
+#include <gdk/gdk.h>
+#include <glib-2.0/glib.h>
+#include <gtk/gtk.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
+#include <xkbcommon/xkbcommon.h>
+
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
+#include "keyboard.h"
+#include "swappy.h"
+
+struct swappy_xkb_us_cache {
+  struct xkb_context *context;
+  struct xkb_keymap *keymap;
+  struct xkb_state *state;
+  gboolean initialized;
+};
+
+static struct swappy_xkb_us_cache swappy_xkb_us = {0};
+
+static gboolean swappy_ensure_us_keymap() {
+  if (swappy_xkb_us.initialized) {
+    return swappy_xkb_us.state != NULL;
+  }
+
+  swappy_xkb_us.initialized = true;
+  swappy_xkb_us.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!swappy_xkb_us.context) {
+    g_warning("failed to create xkb context for physical shortcuts");
+    return false;
+  }
+
+  struct xkb_rule_names names = {0};
+  const gchar *rules = g_getenv("XKB_DEFAULT_RULES");
+  const gchar *model = g_getenv("XKB_DEFAULT_MODEL");
+  const gchar *variant = g_getenv("XKB_DEFAULT_VARIANT");
+  const gchar *options = g_getenv("XKB_DEFAULT_OPTIONS");
+
+  names.rules = (rules && rules[0] != '\0') ? rules : "evdev";
+  names.model = (model && model[0] != '\0') ? model : "pc105";
+  names.layout = "us";
+  names.variant = (variant && variant[0] != '\0') ? variant : NULL;
+  names.options = (options && options[0] != '\0') ? options : NULL;
+  swappy_xkb_us.keymap = xkb_keymap_new_from_names(
+      swappy_xkb_us.context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+  if (!swappy_xkb_us.keymap) {
+    g_warning("failed to create US keymap for physical shortcuts");
+    xkb_context_unref(swappy_xkb_us.context);
+    swappy_xkb_us.context = NULL;
+    return false;
+  }
+
+  swappy_xkb_us.state = xkb_state_new(swappy_xkb_us.keymap);
+  if (!swappy_xkb_us.state) {
+    g_warning("failed to create US keymap state for physical shortcuts");
+    xkb_keymap_unref(swappy_xkb_us.keymap);
+    xkb_context_unref(swappy_xkb_us.context);
+    swappy_xkb_us.keymap = NULL;
+    swappy_xkb_us.context = NULL;
+    return false;
+  }
+
+  return true;
+}
+
+static xkb_keycode_t swappy_event_keycode_xkb(GdkEventKey *event) {
+  xkb_keycode_t keycode = event->hardware_keycode;
+  if (keycode == 0) {
+    return 0;
+  }
+
+#ifdef GDK_WINDOWING_WAYLAND
+  GdkDisplay *display = gdk_display_get_default();
+  if (display && GDK_IS_WAYLAND_DISPLAY(display)) {
+    /* On Wayland, GTK already provides XKB keycodes. */
+    return keycode;
+  }
+#endif
+
+  return keycode;
+}
+
+static gboolean swappy_is_modifier_keyval(guint keyval) {
+  switch (keyval) {
+    case GDK_KEY_Control_L:
+    case GDK_KEY_Control_R:
+    case GDK_KEY_Shift_L:
+    case GDK_KEY_Shift_R:
+    case GDK_KEY_Alt_L:
+    case GDK_KEY_Alt_R:
+    case GDK_KEY_Meta_L:
+    case GDK_KEY_Meta_R:
+    case GDK_KEY_Super_L:
+    case GDK_KEY_Super_R:
+    case GDK_KEY_Hyper_L:
+    case GDK_KEY_Hyper_R:
+    case GDK_KEY_ISO_Level3_Shift:
+    case GDK_KEY_Caps_Lock:
+    case GDK_KEY_Num_Lock:
+    case GDK_KEY_Scroll_Lock:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static xkb_keysym_t swappy_us_keysym_from_event(GdkEventKey *event) {
+  if (!swappy_ensure_us_keymap()) {
+    return XKB_KEY_NoSymbol;
+  }
+
+  xkb_keycode_t keycode = swappy_event_keycode_xkb(event);
+  if (keycode == 0) {
+    return XKB_KEY_NoSymbol;
+  }
+
+  return xkb_state_key_get_one_sym(swappy_xkb_us.state, keycode);
+}
+
+guint keyboard_keysym_for_shortcuts(struct swappy_state *state,
+                                    GdkEventKey *event) {
+  guint sym = event->keyval;
+
+  if (state->config->keyboard_shortcuts != SWAPPY_KEYBOARD_SHORTCUTS_PHYSICAL) {
+    return sym;
+  }
+
+  if (swappy_is_modifier_keyval(sym)) {
+    return sym;
+  }
+
+  xkb_keysym_t us_sym = swappy_us_keysym_from_event(event);
+  if (us_sym != XKB_KEY_NoSymbol) {
+    sym = us_sym;
+  }
+
+  if (event->state & GDK_SHIFT_MASK) {
+    sym = gdk_keyval_to_upper(sym);
+  } else {
+    sym = gdk_keyval_to_lower(sym);
+  }
+
+  return sym;
+}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -117,6 +117,10 @@ guint keyboard_keysym_for_shortcuts(enum swappy_keyboard_shortcuts mode,
   }
 
   if (event->state & GDK_SHIFT_MASK) {
+    if (sym == GDK_KEY_equal) {
+      sym = GDK_KEY_plus;
+    }
+
     sym = gdk_keyval_to_upper(sym);
   } else {
     sym = gdk_keyval_to_lower(sym);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1,33 +1,30 @@
+#include "keyboard.h"
+
 #include <gdk/gdk.h>
 #include <glib-2.0/glib.h>
 #include <gtk/gtk.h>
 #include <xkbcommon/xkbcommon-keysyms.h>
 #include <xkbcommon/xkbcommon.h>
 
-#ifdef GDK_WINDOWING_WAYLAND
-#include <gdk/gdkwayland.h>
-#endif
-
-#include "keyboard.h"
 #include "swappy.h"
 
-struct swappy_xkb_us_cache {
+struct xkb_us_cache {
   struct xkb_context *context;
   struct xkb_keymap *keymap;
   struct xkb_state *state;
   gboolean initialized;
 };
 
-static struct swappy_xkb_us_cache swappy_xkb_us = {0};
+static struct xkb_us_cache xkb_us = {0};
 
-static gboolean swappy_ensure_us_keymap() {
-  if (swappy_xkb_us.initialized) {
-    return swappy_xkb_us.state != NULL;
+static gboolean ensure_us_keymap() {
+  if (xkb_us.initialized) {
+    return xkb_us.state != NULL;
   }
 
-  swappy_xkb_us.initialized = true;
-  swappy_xkb_us.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-  if (!swappy_xkb_us.context) {
+  xkb_us.initialized = true;
+  xkb_us.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (!xkb_us.context) {
     g_warning("failed to create xkb context for physical shortcuts");
     return false;
   }
@@ -43,46 +40,29 @@ static gboolean swappy_ensure_us_keymap() {
   names.layout = "us";
   names.variant = (variant && variant[0] != '\0') ? variant : NULL;
   names.options = (options && options[0] != '\0') ? options : NULL;
-  swappy_xkb_us.keymap = xkb_keymap_new_from_names(
-      swappy_xkb_us.context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
-  if (!swappy_xkb_us.keymap) {
+  xkb_us.keymap = xkb_keymap_new_from_names(xkb_us.context, &names,
+                                            XKB_KEYMAP_COMPILE_NO_FLAGS);
+  if (!xkb_us.keymap) {
     g_warning("failed to create US keymap for physical shortcuts");
-    xkb_context_unref(swappy_xkb_us.context);
-    swappy_xkb_us.context = NULL;
+    xkb_context_unref(xkb_us.context);
+    xkb_us.context = NULL;
     return false;
   }
 
-  swappy_xkb_us.state = xkb_state_new(swappy_xkb_us.keymap);
-  if (!swappy_xkb_us.state) {
+  xkb_us.state = xkb_state_new(xkb_us.keymap);
+  if (!xkb_us.state) {
     g_warning("failed to create US keymap state for physical shortcuts");
-    xkb_keymap_unref(swappy_xkb_us.keymap);
-    xkb_context_unref(swappy_xkb_us.context);
-    swappy_xkb_us.keymap = NULL;
-    swappy_xkb_us.context = NULL;
+    xkb_keymap_unref(xkb_us.keymap);
+    xkb_context_unref(xkb_us.context);
+    xkb_us.keymap = NULL;
+    xkb_us.context = NULL;
     return false;
   }
 
   return true;
 }
 
-static xkb_keycode_t swappy_event_keycode_xkb(GdkEventKey *event) {
-  xkb_keycode_t keycode = event->hardware_keycode;
-  if (keycode == 0) {
-    return 0;
-  }
-
-#ifdef GDK_WINDOWING_WAYLAND
-  GdkDisplay *display = gdk_display_get_default();
-  if (display && GDK_IS_WAYLAND_DISPLAY(display)) {
-    /* On Wayland, GTK already provides XKB keycodes. */
-    return keycode;
-  }
-#endif
-
-  return keycode;
-}
-
-static gboolean swappy_is_modifier_keyval(guint keyval) {
+static gboolean is_modifier_keyval(guint keyval) {
   switch (keyval) {
     case GDK_KEY_Control_L:
     case GDK_KEY_Control_R:
@@ -106,32 +86,32 @@ static gboolean swappy_is_modifier_keyval(guint keyval) {
   }
 }
 
-static xkb_keysym_t swappy_us_keysym_from_event(GdkEventKey *event) {
-  if (!swappy_ensure_us_keymap()) {
+static xkb_keysym_t us_keysym_from_event(GdkEventKey *event) {
+  if (!ensure_us_keymap()) {
     return XKB_KEY_NoSymbol;
   }
 
-  xkb_keycode_t keycode = swappy_event_keycode_xkb(event);
+  xkb_keycode_t keycode = event->hardware_keycode;
   if (keycode == 0) {
     return XKB_KEY_NoSymbol;
   }
 
-  return xkb_state_key_get_one_sym(swappy_xkb_us.state, keycode);
+  return xkb_state_key_get_one_sym(xkb_us.state, keycode);
 }
 
-guint keyboard_keysym_for_shortcuts(struct swappy_state *state,
+guint keyboard_keysym_for_shortcuts(enum swappy_keyboard_shortcuts mode,
                                     GdkEventKey *event) {
   guint sym = event->keyval;
 
-  if (state->config->keyboard_shortcuts != SWAPPY_KEYBOARD_SHORTCUTS_PHYSICAL) {
+  if (mode != SWAPPY_KEYBOARD_SHORTCUTS_PHYSICAL) {
     return sym;
   }
 
-  if (swappy_is_modifier_keyval(sym)) {
+  if (is_modifier_keyval(sym)) {
     return sym;
   }
 
-  xkb_keysym_t us_sym = swappy_us_keysym_from_event(event);
+  xkb_keysym_t us_sym = us_keysym_from_event(event);
   if (us_sym != XKB_KEY_NoSymbol) {
     sym = us_sym;
   }

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -70,6 +70,7 @@ The following lines can be used as swappy's default:
 	custom_color=rgba(192,125,17,1)
 	transparent=false
 	transparency=50
+	keyboard_shortcuts=layout
 ```
 
 - *save_dir* is where swappshots will be saved, can contain env variables, when it does not exist, swappy attempts to create it first, but does not abort if directory creation fails
@@ -86,6 +87,9 @@ The following lines can be used as swappy's default:
 formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/root/etc/X11/rgb.txt),  #rgb, #rrggbb, #rrrgggbbb, #rrrrggggbbbb, rgb(r,b,g), rgba(r,g,b,a)
 - *transparency* is used to set transparency of everything that is drawn during startup
 - *transparent* is used to toggle transparency during startup
+- *keyboard_shortcuts* selects how shortcuts are matched. Use *layout* (default)
+for the active layout symbols, or *physical* to match the US key positions so
+shortcuts still work on non-Latin layouts
 
 
 # KEY BINDINGS
@@ -125,6 +129,9 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 - *Ctrl+s*: Save to file (see man page)
 - *Ctrl+c*: Copy to clipboard
 - *Escape* or *q* or *Ctrl+w*: Quit swappy
+
+If you use a non-Latin keyboard layout, set *keyboard_shortcuts=physical* in the
+config file to match the physical US key positions for all shortcuts.
 
 # AUTHORS
 


### PR DESCRIPTION
## Summary:
  - Added `keyboard_shortcuts` config option with `layout` (default) and `physical` modes.
  - Implemented physical key mapping using libxkbcommon so shortcuts follow US key positions on non-Latin layouts.
  
## Notes:
  - Physical mode requires libxkbcommon at build time (documented in README).

Fix #122 