### PR TITLE
feat(paint): add shift constraint and extend ctrl centering to blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ transparency=50
 
 <hr>
 
-- `Ctrl`: Center Shape (Rectangle & Ellipse) based on draw start
+- `Ctrl`: Center Shape (Rectangle, Ellipse & Blur) based on draw start
+- `Shift`: Constrain Shape to Square (Rectangle & Blur) or Circle (Ellipse)
 
 <hr>
 

--- a/include/paint.h
+++ b/include/paint.h
@@ -7,7 +7,8 @@
 void paint_add_temporary(struct swappy_state *state, double x, double y,
                          enum swappy_paint_type type);
 void paint_update_temporary_shape(struct swappy_state *state, double x,
-                                  double y, gboolean is_control_pressed);
+                                  double y, gboolean is_control_pressed,
+                                  gboolean is_shift_pressed);
 void paint_update_temporary_text(struct swappy_state *state,
                                  GdkEventKey *event);
 void paint_update_temporary_str(struct swappy_state *state, char *event);

--- a/include/swappy.h
+++ b/include/swappy.h
@@ -62,6 +62,7 @@ struct swappy_paint_shape {
   double a;
   double w;
   bool should_center_at_from;
+  bool should_constrain_to_square;
   struct swappy_point from;
   struct swappy_point to;
   enum swappy_paint_type type;
@@ -78,6 +79,8 @@ struct swappy_paint_brush {
 };
 
 struct swappy_paint_blur {
+  bool should_center_at_from;
+  bool should_constrain_to_square;
   struct swappy_point from;
   struct swappy_point to;
   cairo_surface_t *surface;

--- a/src/application.c
+++ b/src/application.c
@@ -387,19 +387,27 @@ void copy_clicked_handler(GtkWidget *widget, struct swappy_state *state) {
   clipboard_copy_drawing_area_to_selection(state);
 }
 
-void control_modifier_changed(bool pressed, struct swappy_state *state) {
-  if (state->temp_paint != NULL) {
-    switch (state->temp_paint->type) {
-      case SWAPPY_PAINT_MODE_ELLIPSE:
-      case SWAPPY_PAINT_MODE_RECTANGLE:
-        paint_update_temporary_shape(
-            state, state->temp_paint->content.shape.to.x,
-            state->temp_paint->content.shape.to.y, pressed);
-        render_state(state);
-        break;
-      default:
-        break;
-    }
+static void modifier_changed(struct swappy_state *state,
+                             gboolean is_control_pressed,
+                             gboolean is_shift_pressed) {
+  if (state->temp_paint == NULL) return;
+
+  switch (state->temp_paint->type) {
+    case SWAPPY_PAINT_MODE_ELLIPSE:
+    case SWAPPY_PAINT_MODE_RECTANGLE:
+      paint_update_temporary_shape(state, state->temp_paint->content.shape.to.x,
+                                   state->temp_paint->content.shape.to.y,
+                                   is_control_pressed, is_shift_pressed);
+      render_state(state);
+      break;
+    case SWAPPY_PAINT_MODE_BLUR:
+      paint_update_temporary_shape(state, state->temp_paint->content.blur.to.x,
+                                   state->temp_paint->content.blur.to.y,
+                                   is_control_pressed, is_shift_pressed);
+      render_state(state);
+      break;
+    default:
+      break;
   }
 }
 
@@ -525,7 +533,11 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
         action_stroke_size_increase(state);
         break;
       case GDK_KEY_Control_L:
-        control_modifier_changed(true, state);
+        modifier_changed(state, true, event->state & GDK_SHIFT_MASK);
+        break;
+      case GDK_KEY_Shift_L:
+      case GDK_KEY_Shift_R:
+        modifier_changed(state, event->state & GDK_CONTROL_MASK, true);
         break;
       case GDK_KEY_f:
         action_fill_shape_toggle(state, NULL);
@@ -541,19 +553,16 @@ void window_keypress_handler(GtkWidget *widget, GdkEventKey *event,
 
 void window_keyrelease_handler(GtkWidget *widget, GdkEventKey *event,
                                struct swappy_state *state) {
-  if (event->state & GDK_CONTROL_MASK) {
-    switch (event->keyval) {
-      case GDK_KEY_Control_L:
-        control_modifier_changed(false, state);
-        break;
-      default:
-        break;
-    }
-  } else {
-    switch (event->keyval) {
-      default:
-        break;
-    }
+  switch (event->keyval) {
+    case GDK_KEY_Control_L:
+      modifier_changed(state, false, event->state & GDK_SHIFT_MASK);
+      break;
+    case GDK_KEY_Shift_L:
+    case GDK_KEY_Shift_R:
+      modifier_changed(state, event->state & GDK_CONTROL_MASK, false);
+      break;
+    default:
+      break;
   }
 }
 
@@ -643,6 +652,7 @@ void draw_area_motion_notify_handler(GtkWidget *widget, GdkEventMotion *event,
 
   gboolean is_button1_pressed = event->state & GDK_BUTTON1_MASK;
   gboolean is_control_pressed = event->state & GDK_CONTROL_MASK;
+  gboolean is_shift_pressed = event->state & GDK_SHIFT_MASK;
 
   switch (state->mode) {
     case SWAPPY_PAINT_MODE_BLUR:
@@ -651,7 +661,8 @@ void draw_area_motion_notify_handler(GtkWidget *widget, GdkEventMotion *event,
     case SWAPPY_PAINT_MODE_ELLIPSE:
     case SWAPPY_PAINT_MODE_ARROW:
       if (is_button1_pressed) {
-        paint_update_temporary_shape(state, x, y, is_control_pressed);
+        paint_update_temporary_shape(state, x, y, is_control_pressed,
+                                     is_shift_pressed);
         render_state(state);
       }
       break;

--- a/src/paint.c
+++ b/src/paint.c
@@ -153,7 +153,8 @@ void paint_add_temporary(struct swappy_state *state, double x, double y,
 }
 
 void paint_update_temporary_shape(struct swappy_state *state, double x,
-                                  double y, gboolean is_control_pressed) {
+                                  double y, gboolean is_control_pressed,
+                                  gboolean is_shift_pressed) {
   struct swappy_paint *paint = state->temp_paint;
   struct swappy_point *point;
   GList *points;
@@ -165,6 +166,8 @@ void paint_update_temporary_shape(struct swappy_state *state, double x,
   switch (paint->type) {
     case SWAPPY_PAINT_MODE_BLUR:
       paint->can_draw = true;
+      paint->content.blur.should_center_at_from = is_control_pressed;
+      paint->content.blur.should_constrain_to_square = is_shift_pressed;
       paint->content.blur.to.x = x;
       paint->content.blur.to.y = y;
       break;
@@ -181,6 +184,7 @@ void paint_update_temporary_shape(struct swappy_state *state, double x,
       paint->can_draw = true;  // all set
 
       paint->content.shape.should_center_at_from = is_control_pressed;
+      paint->content.shape.should_constrain_to_square = is_shift_pressed;
       paint->content.shape.to.x = x;
       paint->content.shape.to.y = y;
       break;

--- a/src/render.c
+++ b/src/render.c
@@ -285,7 +285,19 @@ static void render_shape_arrow(cairo_t *cr, struct swappy_paint_shape shape) {
   cairo_restore(cr);
 }
 
+static void constrain_to_square(struct swappy_point from,
+                                struct swappy_point *to) {
+  double dx = to->x - from.x;
+  double dy = to->y - from.y;
+  double side = fmax(fabs(dx), fabs(dy));
+  to->x = from.x + ((dx >= 0) ? 1.0 : -1.0) * side;
+  to->y = from.y + ((dy >= 0) ? 1.0 : -1.0) * side;
+}
+
 static void render_shape_ellipse(cairo_t *cr, struct swappy_paint_shape shape) {
+  if (shape.should_constrain_to_square) {
+    constrain_to_square(shape.from, &shape.to);
+  }
   double x = fabs(shape.from.x - shape.to.x);
   double y = fabs(shape.from.y - shape.to.y);
 
@@ -333,6 +345,10 @@ static void render_shape_ellipse(cairo_t *cr, struct swappy_paint_shape shape) {
 static void render_shape_rectangle(cairo_t *cr,
                                    struct swappy_paint_shape shape) {
   double x, y, w, h;
+
+  if (shape.should_constrain_to_square) {
+    constrain_to_square(shape.from, &shape.to);
+  }
 
   if (shape.should_center_at_from) {
     x = shape.from.x - fabs(shape.from.x - shape.to.x);
@@ -394,12 +410,23 @@ static void clear_surface(cairo_t *cr) {
 static void render_blur(cairo_t *cr, struct swappy_paint *paint) {
   struct swappy_paint_blur blur = paint->content.blur;
 
+  if (blur.should_constrain_to_square) constrain_to_square(blur.from, &blur.to);
+
   cairo_surface_t *target = cairo_get_target(cr);
 
-  double x = MIN(blur.from.x, blur.to.x);
-  double y = MIN(blur.from.y, blur.to.y);
-  double w = ABS(blur.from.x - blur.to.x);
-  double h = ABS(blur.from.y - blur.to.y);
+  double x, y, w, h;
+
+  if (blur.should_center_at_from) {
+    x = blur.from.x - ABS(blur.from.x - blur.to.x);
+    y = blur.from.y - ABS(blur.from.y - blur.to.y);
+    w = ABS(blur.from.x - blur.to.x) * 2;
+    h = ABS(blur.from.y - blur.to.y) * 2;
+  } else {
+    x = MIN(blur.from.x, blur.to.x);
+    y = MIN(blur.from.y, blur.to.y);
+    w = ABS(blur.from.x - blur.to.x);
+    h = ABS(blur.from.y - blur.to.y);
+  }
 
   cairo_save(cr);
 
@@ -433,6 +460,7 @@ static void render_blur(cairo_t *cr, struct swappy_paint *paint) {
         .b = 1,
         .a = 0.5,
         .w = 5,
+        .should_center_at_from = blur.should_center_at_from,
         .from = blur.from,
         .to = blur.to,
         .type = SWAPPY_PAINT_MODE_RECTANGLE,

--- a/swappy.1.scd
+++ b/swappy.1.scd
@@ -116,7 +116,8 @@ formats are: standard name (one of: https://github.com/rgb-x/system/blob/master/
 
 ## MODIFIERS
 
-- *Ctrl*: Center Shape (Rectangle & Ellipse) based on draw start
+- *Ctrl*: Center Shape (Rectangle, Ellipse & Blur) based on draw start
+- *Shift*: Constrain Shape to Square (Rectangle & Blur) or Circle (Ellipse)
 
 ## HEADER BAR
 


### PR DESCRIPTION
Holding Shift while drawing now constrains rectangles to squares and ellipses to circles. Both the Shift constraint and the existing Ctrl centering also apply to the blur tool, and the two modifiers compose (Ctrl+Shift draws a centered square/circle).